### PR TITLE
feat: upgrade Langflow from 1.10.1 to 1.10.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This repository provides a PowerShell wrapper script (`install-langflow-script.ps1`) and companion batch launcher (`Install Langflow.bat`) to install Langflow on Windows using `uv` as the package manager. Python 3.12 is pinned. Langflow is pinned to version **1.10.1**.
+This repository provides a PowerShell wrapper script (`install-langflow-script.ps1`) and companion batch launcher (`Install Langflow.bat`) to install Langflow on Windows using `uv` as the package manager. Python 3.12 is pinned. Langflow is pinned to version **1.10.2**.
 
 **Author**: Nikki Satmaka
 - GitHub: https://github.com/NikkiSatmaka/
@@ -28,7 +28,7 @@ This repository provides a PowerShell wrapper script (`install-langflow-script.p
 - **Idempotent** — safe to re-run; checks before acting
 - **User-prompted** — script asks Install / Uninstall / Quit at startup
 - **Credits banner** — GitHub + LinkedIn displayed on every run (Chris Titus style)
-- **Version pinned** — Langflow `==1.10.1`; do not change without updating CONTRACT.md
+- **Version pinned** — Langflow `==1.10.2`; do not change without updating CONTRACT.md
 - **Python pinned** — 3.12 via `uv python install 3.12` (only version with pre-built wheels for all C-extensions on Windows; 3.13+ requires MSVC not available to most users)
 
 ## Key Design Decisions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.5.0 (2026-07-08)
+- feat: update Langflow from 1.10.1 to 1.10.2
+
 ## v1.4.0 (2026-06-25)
 - feat: update Langflow from 1.9.6 to 1.10.1
 - docs: replace ASCII banner with badges in README, update docs for v1.4.0

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -2,7 +2,7 @@
 
 ## 1. Purpose
 
-Provide a single-click (or double-click) solution for Windows users to install, run, and uninstall Langflow (`==1.10.1`) using `uv` as the package manager, with no administrative privileges required.
+Provide a single-click (or double-click) solution for Windows users to install, run, and uninstall Langflow (`==1.10.2`) using `uv` as the package manager, with no administrative privileges required.
 
 ## 2. Credits & Attribution
 
@@ -58,7 +58,7 @@ Run when the user selects `[I]`.
 1. Create `%USERPROFILE%\langflow\` directory if it does not exist.
 2. `cd %USERPROFILE%\langflow`
 3. Create venv: `uv venv` (creates `.venv`).
-4. Install Langflow: `uv pip install langflow==1.10.1`.
+4. Install Langflow: `uv pip install langflow==1.10.2`.
    - If the pin fails (e.g., version yanked), catch the error and suggest `uv pip install langflow` without the pin as a fallback.
 
 ### 4.4 Desktop Shortcut
@@ -77,7 +77,7 @@ Run when the user selects `[I]`.
 Print a success summary:
 
 ```
-✓ Langflow 1.10.1 installed
+✓ Langflow 1.10.2 installed
 ✓ Desktop shortcut created: %USERPROFILE%\Desktop\Langflow.lnk
 ➜ Double-click the shortcut to start Langflow
 ➜ Browser opens automatically at http://127.0.0.1:7860
@@ -120,7 +120,7 @@ Run when the user selects `[U]`.
 | PATH not refreshed after uv install | Read permanent PATH from registry into current session explicitly |
 | Langflow download is large (~300MB) | Stream uv pip output; print "This may take a few minutes..." beforehand |
 | Port 7860 conflict | Document in completion message; user can configure via `.env` |
-| langflow==1.10.1 yanked on PyPI | Catch the pip error and suggest removing the version pin |
+| langflow==1.10.2 yanked on PyPI | Catch the pip error and suggest removing the version pin |
 | WScript.Shell missing on N/KN editions | Catch COM error and print manual shortcut instructions |
 | Antivirus flags `irm \| iex` pattern | Bundle `uv-install.ps1` in the release zip; invoke via `& "$PSScriptRoot\uv-install.ps1"` instead of downloading at runtime |
 | uv binary not on PATH after install | Explicitly add `%USERPROFILE%\.local\bin` to permanent PATH in script |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Langflow Installer for Windows
 
-One-click installer for [Langflow](https://github.com/langflow-ai/langflow) **1.10.1** on Windows 10/11 — no admin rights required.
+One-click installer for [Langflow](https://github.com/langflow-ai/langflow) **1.10.2** on Windows 10/11 — no admin rights required.
 
 [![GitHub](https://img.shields.io/badge/GitHub-NikkiSatmaka-181717?style=for-the-badge&logo=github)](https://github.com/NikkiSatmaka/)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-nikkisatmaka-0A66C2?style=for-the-badge&logo=linkedin)](https://linkedin.com/in/nikkisatmaka/)
@@ -15,7 +15,7 @@ That's it. The script will:
 - Install `uv` (self-bootstrapping package manager)
 - Download Python 3.12
 - Create a virtual environment in `%USERPROFILE%\langflow\`
-- Install Langflow 1.10.1
+- Install Langflow 1.10.2
 - Create a desktop shortcut (`Langflow.lnk`)
 
 After install, double-click the desktop shortcut. A terminal window will open, and your browser will launch automatically once the Langflow server is ready at `http://127.0.0.1:7860`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,7 +110,7 @@
     <div class="hero">
       <span class="badge">No admin rights required</span>
       <h1>Langflow for Windows</h1>
-      <p>Install Langflow 1.10.1 with one click. No Python or package manager needed.</p>
+      <p>Install Langflow 1.10.2 with one click. No Python or package manager needed.</p>
     </div>
 
     <!-- Download -->
@@ -145,7 +145,7 @@
       <li>Installs <strong>uv</strong> (a fast Python package manager)</li>
       <li>Downloads <strong>Python 3.12</strong></li>
       <li>Creates a virtual environment in <code>%USERPROFILE%\langflow\</code></li>
-      <li>Installs <strong>Langflow 1.10.1</strong></li>
+      <li>Installs <strong>Langflow 1.10.2</strong></li>
       <li>Creates a <strong>desktop shortcut</strong> (<em>Langflow.lnk</em>)</li>
     </ul>
 

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -3,7 +3,7 @@
     Install or uninstall Langflow on Windows using uv.
 .DESCRIPTION
     Bootstraps uv, installs Python 3.12, creates a virtual environment,
-    installs Langflow 1.10.1, and creates a desktop shortcut.
+    installs Langflow 1.10.2, and creates a desktop shortcut.
     Also supports clean uninstall of all components.
 .NOTES
     Author: Nikki Satmaka
@@ -13,8 +13,8 @@
 
 #Requires -Version 5.1
 
-$ScriptVersion   = "1.0.0"
-$LangflowVersion = "1.10.1"
+$ScriptVersion   = "1.5.0"
+$LangflowVersion = "1.10.2"
 $LangflowDir     = "$env:USERPROFILE\langflow"
 $UvBinDir        = "$env:USERPROFILE\.local\bin"
 $ShortcutName    = "Langflow.lnk"


### PR DESCRIPTION
This PR bumps the installed Langflow version from 1.10.1 to 1.10.2. Python stays pinned at 3.12.

**Files changed:**
- `src/install-langflow-script.ps1` — `` 1.10.1 → 1.10.2, `` 1.0.0 → 1.5.0
- `README.md` — hero line and what-it-does list
- `CONTRACT.md` — purpose, install step, completion message, and risk table
- `AGENTS.md` — project overview and design constraints
- `docs/index.html` — hero and what-it-does list
- `CHANGELOG.md` — added v1.5.0 entry

All verification checks pass (braces balanced, no stale version refs, version consistency confirmed).