### PR TITLE
docs: release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.6.0-beta.3 (2026-07-08)
+## v1.6.0 (2026-07-08)
 
 - fix: redirect menu display to stderr so choice capture works
 - fix: banner alignment (off-by-1 on the title line)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ One-click installer for [Langflow](https://github.com/langflow-ai/langflow) **1.
 [![GitHub](https://img.shields.io/badge/GitHub-NikkiSatmaka-181717?style=for-the-badge&logo=github)](https://github.com/NikkiSatmaka/)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-nikkisatmaka-0A66C2?style=for-the-badge&logo=linkedin)](https://linkedin.com/in/nikkisatmaka/)
 
-> **Beta**: This project supports macOS and Linux in addition to Windows. See the [landing page](https://nikkisatmaka.github.io/langflow-installer-wrapper/) for a visual guide.
 
 ## Downloads
 

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -13,7 +13,7 @@
 
 #Requires -Version 5.1
 
-$ScriptVersion   = "1.6.0-beta.1"
+$ScriptVersion   = "1.6.0"
 $LangflowVersion = "1.10.2"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 OS="$(uname -s)"
-SCRIPT_VERSION="1.6.0-beta.1"
+SCRIPT_VERSION="1.6.0"
 LANGFLOW_VERSION="1.10.2"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
This PR removes beta status from v1.6.0: bumps script versions to GA, removes the beta callout from README, and updates the CHANGELOG heading.