### PR TITLE
fix: use ${PythonVersion} to prevent drive-qualified parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.6.2 (2026-07-14)
+
+- fix: use ${PythonVersion} to prevent drive-qualified parse error
+
 ## v1.6.1 (2026-07-14)
 
 - fix: use ${_} syntax in PowerShell scripts to prevent parser error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.6.1 (2026-07-14)
+
+- fix: use ${_} syntax in PowerShell scripts to prevent parser error
+
 ## v1.6.0 (2026-07-08)
 
 - feat: macOS and Linux installer (cross-platform support)

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -13,7 +13,7 @@
 
 #Requires -Version 5.1
 
-$ScriptVersion   = "1.6.0"
+$ScriptVersion   = "1.6.1"
 $LangflowVersion = "1.10.2"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -13,7 +13,7 @@
 
 #Requires -Version 5.1
 
-$ScriptVersion   = "1.6.1"
+$ScriptVersion   = "1.6.2"
 $LangflowVersion = "1.10.2"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -104,7 +104,7 @@ function Install-Python {
         uv python install $PythonVersion 2>&1 | Out-Null
     }
     catch {
-        Write-Fail "Failed to install Python $PythonVersion: ${_}"
+        Write-Fail "Failed to install Python ${PythonVersion}: ${_}"
         return $false
     }
 
@@ -379,7 +379,7 @@ function Start-Uninstall {
             Write-Ok "Python $PythonVersion removed"
         }
         catch {
-            Write-Warn "Could not remove Python $PythonVersion: ${_}"
+            Write-Warn "Could not remove Python ${PythonVersion}: ${_}"
         }
     }
 

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 OS="$(uname -s)"
-SCRIPT_VERSION="1.6.0"
+SCRIPT_VERSION="1.6.1"
 LANGFLOW_VERSION="1.10.2"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 OS="$(uname -s)"
-SCRIPT_VERSION="1.6.1"
+SCRIPT_VERSION="1.6.2"
 LANGFLOW_VERSION="1.10.2"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
This PR wraps `$PythonVersion` in curly braces (`${PythonVersion}`) wherever it appears before a colon in double-quoted strings. PowerShell was interpreting `$PythonVersion:` as drive-qualified syntax (like `$env:PATH`), causing a parser error.