### PR TITLE
fix: pin litellm<1.92.0 to avoid Rust build requirement on Windows

### DIFF
--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -146,7 +146,7 @@ function Install-LangflowPackage {
 
         $installOk = $false
 
-        uv pip install "langflow==$LangflowVersion" 2>&1 | ForEach-Object { Write-Host "   $_" }
+        uv pip install "langflow==$LangflowVersion" "litellm>=1.85.1,<1.92.0" 2>&1 | ForEach-Object { Write-Host "   $_" }
         if ($LASTEXITCODE -eq 0) {
             $installOk = $true
         }

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -123,7 +123,7 @@ install_langflow_package() {
     info "Installing Langflow ${LANGFLOW_VERSION} (this may take a few minutes)..."
 
     install_ok=false
-    if uv pip install "langflow==${LANGFLOW_VERSION}" 2>&1; then
+    if uv pip install "langflow==${LANGFLOW_VERSION}" "litellm>=1.85.1,<1.92.0" 2>&1; then
         install_ok=true
     else
         warn "Version ${LANGFLOW_VERSION} failed -- trying latest..."


### PR DESCRIPTION
This PR pins litellm to <1.92.0 in both installer scripts.

litellm 1.92.0 dropped `py3-none-any.whl` and only ships `manylinux` wheels plus a source tarball containing Rust OCR code. On Windows and macOS, uv falls back to the tarball and fails without C++ build tools / Rust toolchain installed.

Pinning to `>=1.85.1,<1.92.0` lets the resolver pick 1.91.3, which still ships a pure Python wheel.

This constraint can be removed once litellm publishes `win_amd64` and `macosx` wheels.