### PR TITLE
docs: add star the repo CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ One-click installer for [Langflow](https://github.com/langflow-ai/langflow) **1.
 
 [![GitHub](https://img.shields.io/badge/GitHub-NikkiSatmaka-181717?style=for-the-badge&logo=github)](https://github.com/NikkiSatmaka/)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-nikkisatmaka-0A66C2?style=for-the-badge&logo=linkedin)](https://linkedin.com/in/nikkisatmaka/)
+[![GitHub stars](https://img.shields.io/github/stars/NikkiSatmaka/langflow-installer-wrapper?style=for-the-badge&logo=github)](https://github.com/NikkiSatmaka/langflow-installer-wrapper/stargazers)
 
+> If you find this useful, please star the repo!
 
 ## Downloads
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -136,6 +136,7 @@
       <span class="badge">No admin rights required</span>
       <h1>Langflow for Windows, macOS, and Linux</h1>
       <p>Install Langflow 1.10.2 with one click. No Python or package manager needed.</p>
+      <iframe src="https://ghbtns.com/github-btn.html?user=NikkiSatmaka&repo=langflow-installer-wrapper&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160" height="30" title="GitHub" style="margin-top: 1rem;"></iframe>
     </div>
 
     <!-- Radio inputs for tabs -->


### PR DESCRIPTION
This PR adds a star the repo call-to-action to both the README and the landing page.

- README: stars badge added to the badge row + a one-line CTA before Downloads
- Landing page: GitHub star button (ghbtns widget) in the hero section, below the subtitle