### PR TITLE
docs: update docs and landing page for Langflow Web shortcut, add troubleshooting entries

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -78,9 +78,9 @@ Run when the user selects `[I]`.
 Two shortcuts are created: one to start Langflow, one to stop it.
 
 **Start shortcut:**
-- **Windows**: Create `Langflow.lnk` using `WScript.Shell` COM pointing to `run-langflow.bat`. If COM is unavailable, print the shortcut path for manual creation.
-- **macOS**: Create `~/Desktop/Langflow.command` that executes the launcher script. Make it executable with `chmod +x`.
-- **Linux**: Create `langflow.desktop` at `~/.local/share/applications/` and copy to `~/Desktop/`. On GNOME, mark as trusted via `gio set metadata::trusted true`.
+- **Windows**: Create `Langflow Web.lnk` using `WScript.Shell` COM pointing to `run-langflow.bat`. Set `IconLocation` to the bundled `langflow.ico`. If COM is unavailable, print the shortcut path for manual creation.
+- **macOS**: Create `~/Desktop/Langflow Web.command` that executes the launcher script. Make it executable with `chmod +x`. The `.command` keeps the default Finder icon by design.
+- **Linux**: Create `langflow.desktop` at `~/.local/share/applications/` (with `Name=Langflow Web` and `Icon=` pointing at the bundled `langflow.png`) and copy to `~/Desktop/`. On GNOME, mark as trusted via `gio set metadata::trusted true`.
 
 **Stop shortcut:**
 - **Windows**: Create `Stop Langflow.lnk` pointing to `stop-langflow-script.ps1`.
@@ -112,8 +112,8 @@ Run when the user selects `[U]`.
    - **Windows**: `%USERPROFILE%\langflow\` (recursive)
    - **macOS/Linux**: `~/langflow/` (recursive)
 3. Remove desktop shortcuts (start and stop):
-   - **Windows**: `%USERPROFILE%\Desktop\Langflow.lnk` and `%USERPROFILE%\Desktop\Stop Langflow.lnk`
-   - **macOS**: `~/Desktop/Langflow.command` and `~/Desktop/Stop Langflow.command`
+   - **Windows**: `%USERPROFILE%\Desktop\Langflow Web.lnk` and `%USERPROFILE%\Desktop\Stop Langflow.lnk`
+   - **macOS**: `~/Desktop/Langflow Web.command` and `~/Desktop/Stop Langflow.command`
    - **Linux**: `~/.local/share/applications/langflow.desktop`, `~/Desktop/langflow.desktop`, `~/.local/share/applications/stop-langflow.desktop`, and `~/Desktop/stop-langflow.desktop`
 4. Ask: `Remove Python 3.12 installed by uv? [y/N]`
    - If `Y`, run `uv python uninstall 3.12`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The script will:
 - Install Langflow 1.10.2
 - Create desktop shortcuts (`Langflow Web.lnk` and `Stop Langflow.lnk`)
 
-After install, double-click the **Langflow** desktop shortcut. A terminal window will open, and your browser will launch automatically once the server is ready at `http://127.0.0.1:7860`. To stop the server, double-click **Stop Langflow**.
+After install, double-click the **Langflow Web** desktop shortcut. A terminal window will open, and your browser will launch automatically once the server is ready at `http://127.0.0.1:7860`. To stop the server, double-click **Stop Langflow**.
 
 > **Having trouble?** See [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) for Smart App Control and antivirus help.
 
@@ -46,9 +46,9 @@ The script will:
 - Download Python 3.12
 - Create a virtual environment in `~/langflow/`
 - Install Langflow 1.10.2
-- Create desktop shortcuts (`Langflow.command` and `Stop Langflow.command`)
+- Create desktop shortcuts (`Langflow Web.command` and `Stop Langflow.command`)
 
-After install, double-click the **Langflow** desktop shortcut. Terminal will open, start the server, and open your browser automatically. To stop the server, double-click **Stop Langflow**.
+After install, double-click the **Langflow Web** desktop shortcut. Terminal will open, start the server, and open your browser automatically. To stop the server, double-click **Stop Langflow**.
 
 ## Quick Start (Linux)
 
@@ -63,7 +63,7 @@ The script will:
 - Install Langflow 1.10.2
 - Create desktop shortcuts in your app menu and on your desktop (for both starting and stopping Langflow)
 
-After install, launch Langflow from your app menu or desktop shortcut. A terminal will open, start the server, and open your browser automatically. To stop the server, find **Stop Langflow** in your app menu or desktop.
+After install, launch **Langflow Web** from your app menu or desktop shortcut. A terminal will open, start the server, and open your browser automatically. To stop the server, find **Stop Langflow** in your app menu or desktop.
 
 ## Running manually
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -41,3 +41,26 @@ If the desktop shortcut file (`langflow.desktop`) appears as a text file, you ma
 ```bash
 chmod +x ~/Desktop/langflow.desktop
 ```
+
+## PyTorch fails to install or load (Windows)
+
+Some packages (for example PyTorch) require the Visual C++ Redistributable. If it is missing, `uv pip install` may fail with an error about `VCRUNTIME140.dll` or `msvcp140.dll`.
+
+**To fix:**
+1. Download the Visual C++ Redistributable (x64) from Microsoft: <https://aka.ms/vc14/vc_redist.x64.exe>
+2. Run the installer and follow the prompts (you may need to approve a UAC prompt).
+3. Re-run the Langflow installer and choose **Install**.
+
+> The redistributable is safe and published by Microsoft. Many Python packages with native C++ extensions (including PyTorch) depend on it.
+
+## Langflow won't start or behaves oddly
+
+Corrupted cache or stale data can cause Langflow to fail on startup or act unexpectedly. Deleting its cache gives it a clean slate.
+
+**To fix:** stop Langflow, then delete its cache directory:
+
+- **Windows**: Delete `C:\Users\<you>\AppData\Local\langflow` (or run `rmdir /s "%LOCALAPPDATA%\langflow"` in a terminal)
+- **macOS**: Delete `~/Library/Caches/langflow` (or run `rm -rf ~/Library/Caches/langflow`)
+- **Linux**: Delete `~/.cache/langflow` (or run `rm -rf ~/.cache/langflow`)
+
+Then start Langflow again from the desktop shortcut. Your installed packages stay in place — only cached data is removed.

--- a/docs/index.html
+++ b/docs/index.html
@@ -193,14 +193,15 @@
         <li>Downloads <strong>Python 3.12</strong></li>
         <li>Creates a virtual environment in <code>%USERPROFILE%\langflow\</code></li>
         <li>Installs <strong>Langflow 1.10.2</strong></li>
-        <li>Creates <strong>desktop shortcuts</strong> (<em>Langflow.lnk</em> and <em>Stop Langflow.lnk</em>)</li>
+        <li>Creates <strong>desktop shortcuts</strong> (<em>Langflow Web.lnk</em> and <em>Stop Langflow.lnk</em>)</li>
+        <li>Adds the <strong>Langflow icon</strong> to the launch shortcut</li>
       </ul>
 
       <h2>How to run</h2>
       <div class="steps">
         <div class="step">
           <div class="step-num">1</div>
-          <div><strong>Find the Langflow shortcut</strong><p>Look for <em>Langflow.lnk</em> on your desktop. The installer created it for you.</p></div>
+          <div><strong>Find the Langflow Web shortcut</strong><p>Look for <em>Langflow Web.lnk</em> on your desktop. The installer created it for you.</p></div>
         </div>
         <div class="step">
           <div class="step-num">2</div>
@@ -270,14 +271,14 @@
         <li>Downloads <strong>Python 3.12</strong></li>
         <li>Creates a virtual environment in <code>~/langflow/</code></li>
         <li>Installs <strong>Langflow 1.10.2</strong></li>
-        <li>Creates <strong>desktop shortcuts</strong> (<em>Langflow.command</em> and <em>Stop Langflow.command</em>)</li>
+        <li>Creates <strong>desktop shortcuts</strong> (<em>Langflow Web.command</em> and <em>Stop Langflow.command</em>)</li>
       </ul>
 
       <h2>How to run</h2>
       <div class="steps">
         <div class="step">
           <div class="step-num">1</div>
-          <div><strong>Find the Langflow shortcut</strong><p>Look for <em>Langflow.command</em> on your desktop. The installer created it for you.</p></div>
+          <div><strong>Find the Langflow Web shortcut</strong><p>Look for <em>Langflow Web.command</em> on your desktop. The installer created it for you.</p></div>
         </div>
         <div class="step">
           <div class="step-num">2</div>
@@ -332,13 +333,14 @@
         <li>Creates a virtual environment in <code>~/langflow/</code></li>
         <li>Installs <strong>Langflow 1.10.2</strong></li>
         <li>Creates <strong>desktop shortcuts</strong> in your app menu and on your desktop for both starting and stopping Langflow</li>
+        <li>Adds the <strong>Langflow icon</strong> to the launch shortcut</li>
       </ul>
 
       <h2>How to run</h2>
       <div class="steps">
         <div class="step">
           <div class="step-num">1</div>
-          <div><strong>Find Langflow in your app menu</strong><p>Look for <em>Langflow</em> in your application menu under <em>Development</em>. Or find <em>langflow.desktop</em> on your desktop.</p></div>
+          <div><strong>Find Langflow Web in your app menu</strong><p>Look for <em>Langflow Web</em> in your application menu under <em>Development</em>. Or find <em>langflow.desktop</em> on your desktop.</p></div>
         </div>
         <div class="step">
           <div class="step-num">2</div>


### PR DESCRIPTION
## What

Two documentation changes in one PR:

1. **Update docs for the renamed launch shortcut.** README, landing page (docs/index.html), and CONTRACT.md now refer to the launch shortcut as "Langflow Web" (instead of just "Langflow") across all platform sections. The stop shortcut name is unchanged.

2. **Add two new troubleshooting entries** in docs/TROUBLESHOOTING.md:
   - PyTorch fails on Windows — directs users to download the VC++ Redistributable from Microsoft.
   - Langflow won't start or behaves oddly — clears the cache at `%LOCALAPPDATA%\langflow` (Windows), `~/Library/Caches/langflow` (macOS), or `~/.cache/langflow` (Linux).

## Verification

- `bash scripts/verify.sh` passes all 11 checks.
- Landing page HTML renders the corrected shortcut names.
