### PR TITLE
docs: update changelog for v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.7.0 (2026-07-17)
+
+- feat: rename desktop launcher to Langflow Web (distinct from other Langflow shortcuts)
+- feat: bundle Langflow icon and apply to launch shortcuts (Windows .ico, Linux .desktop Icon=)
+- docs: update docs and landing page for Langflow Web shortcut
+- docs: add troubleshooting entries for PyTorch/vcredist and Langflow cache
+
 ## v1.6.3 (2026-07-15)
 
 - fix: pin litellm<1.92.0 to avoid Rust build requirement on Windows/macOS

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -17,7 +17,7 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion = "1.6.3"
+$ScriptVersion = "1.7.0"
 $LangflowVersion = "1.10.2"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.6.3"
+SCRIPT_VERSION="1.7.0"
 LANGFLOW_VERSION="1.10.2"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
## What

Prepare v1.7.0 release: version bump and changelog.

## Changes since v1.6.3

- feat: rename desktop launcher to Langflow Web (distinct from other Langflow shortcuts)
- feat: bundle Langflow icon and apply to launch shortcuts (Windows .ico, Linux .desktop Icon=)
- docs: update docs and landing page for Langflow Web shortcut
- docs: add troubleshooting entries for PyTorch/vcredist and Langflow cache

## Verification

- `bash scripts/verify.sh` passes all 11 checks.
- `$ScriptVersion` / `SCRIPT_VERSION` bumped to 1.7.0.
