### PR TITLE
fix: add mise setup to release workflow verify step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+      - name: Install PSScriptAnalyzer
+        run: mise exec -- pwsh -NoProfile -Command "Install-Module PSScriptAnalyzer -Scope CurrentUser -Force"
       - run: bash scripts/verify.sh
 
   package:


### PR DESCRIPTION
This PR adds mise and PSScriptAnalyzer setup to the release workflow's verify job so `mise run lint` passes in CI.

## Changes

- Adds `jdx/mise-action@v2` step to the verify job
- Installs PSScriptAnalyzer via `mise exec` before running verification

## Why

Commit `999145a` was pushed to `release/v1.7.0` after PR #20 was merged, adding the missing mise setup to the release CI. This PR brings that fix to `main`.