### PR TITLE
docs: update changelog for v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.8.0 (2026-07-23)
+
+- feat: upgrade Langflow from 1.10.2 to 1.10.3
+
 ## v1.7.0 (2026-07-17)
 
 - feat: rename desktop launcher to Langflow Web (distinct from other Langflow shortcuts)

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -17,7 +17,7 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion = "1.7.0"
+$ScriptVersion = "1.8.0"
 $LangflowVersion = "1.10.3"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.7.0"
+SCRIPT_VERSION="1.8.0"
 LANGFLOW_VERSION="1.10.3"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
# v1.8.0 Release Prep

- feat: upgrade Langflow from 1.10.2 to 1.10.3
- Script version bumped from 1.7.0 to 1.8.0
- CHANGELOG.md updated

## Verification

- [x] All version references consistent
- [x] `bash scripts/verify.sh` passes (11/11)

After merge, push tag `v1.8.0` from main to trigger CI release.