### PR TITLE
fix: pass constraints as separate args to uv on Windows

### DIFF
--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -150,18 +150,18 @@ function Install-LangflowPackage {
         Write-Info "Installing Langflow $LangflowVersion (this may take a few minutes)..."
 
         $installOk = $false
-        $constraintsArg = ""
+        $constraintsArgs = @()
         if (Test-Path $ConstraintsFile) {
-            $constraintsArg = "--constraint $ConstraintsFile"
+            $constraintsArgs = @('--constraint', $ConstraintsFile)
         }
 
-        uv pip install "langflow==$LangflowVersion" $constraintsArg 2>&1 | ForEach-Object { Write-Host "   $_" }
+        uv pip install "langflow==$LangflowVersion" @constraintsArgs 2>&1 | ForEach-Object { Write-Host "   $_" }
         if ($LASTEXITCODE -eq 0) {
             $installOk = $true
         }
         else {
             Write-Warn "Version $LangflowVersion failed -- trying latest..."
-            uv pip install langflow $constraintsArg 2>&1 | ForEach-Object { Write-Host "   $_" }
+            uv pip install langflow @constraintsArgs 2>&1 | ForEach-Object { Write-Host "   $_" }
             if ($LASTEXITCODE -eq 0) {
                 $installOk = $true
             }


### PR DESCRIPTION
This PR fixes the Windows installer bouncing back to the menu after choosing Install. PowerShell passed the constraint as a single token (e.g. `--constraint C:\...\constraints.txt`), which clap rejects, so uv pip install always failed and Start-Install returned early. It now splats an array so `--constraint` and the path arrive as separate arguments, matching the bash installer.