### PR TITLE
docs: update changelog for v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.9.1 (2026-08-03)
+
+- fix: pass constraints as separate args to uv on Windows
+
 ## v1.9.0 (2026-08-02)
 
 - feat: upgrade Langflow to 1.11.1

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -17,7 +17,7 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion   = "1.9.0"
+$ScriptVersion   = "1.9.1"
 $LangflowVersion = "1.11.1"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.9.0"
+SCRIPT_VERSION="1.9.1"
 LANGFLOW_VERSION="1.11.1"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
This PR bumps the installer to v1.9.1 for the Windows uv constraint argument fix and adds the changelog entry. After merge, tag v1.9.1 triggers the automated release.