### PR TITLE
feat: run the actual install scripts in CI

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -105,12 +105,13 @@ jobs:
 
       - name: Run the real installer script
         shell: bash
+        timeout-minutes: 15
         run: |
           mkdir -p "$HOME/Desktop"
           if [ "$RUNNER_OS" = "Windows" ]; then
-            printf 'I\n\n' | timeout 900 powershell.exe -NoProfile -ExecutionPolicy Bypass -File src/install-langflow-script.ps1
+            printf 'I\n\n' | powershell.exe -NoProfile -ExecutionPolicy Bypass -File src/install-langflow-script.ps1
           else
-            printf 'I\n\n' | timeout 900 bash src/install-langflow.sh
+            printf 'I\n\n' | bash src/install-langflow.sh
           fi
 
       - name: Verify installation

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,4 +1,4 @@
-name: Constraint Test
+name: Install Test
 
 on:
   workflow_call:
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  constraint-test:
+  install-test:
     strategy:
       fail-fast: false
       matrix:
@@ -24,6 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
+
+      - name: Pin global uv version for mise shims
+        shell: bash
+        run: |
+          UV_VER=$(awk -F '"' '/^uv =/{print $2; exit}' mise.toml)
+          mise use -g "uv@${UV_VER}"
 
       - name: Install Python 3.12
         run: uv python install 3.12
@@ -97,30 +103,28 @@ jobs:
           echo "LANGFLOW_VERSION=$LF_VER" >> "$GITHUB_ENV"
           echo "Pinned Langflow version: $LF_VER"
 
-      - name: Create venv and install langflow with constraints
+      - name: Run the real installer script
         shell: bash
         run: |
-          uv venv .venv
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            uv pip install "$(ls src/litellm-*.whl | head -1)"
+          mkdir -p "$HOME/Desktop"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            printf 'I\n\n' | timeout 900 powershell.exe -NoProfile -ExecutionPolicy Bypass -File src/install-langflow-script.ps1
+          else
+            printf 'I\n\n' | timeout 900 bash src/install-langflow.sh
           fi
-          uv pip install "langflow==${LANGFLOW_VERSION}" --constraint src/constraints.txt 2>&1 | tee /tmp/uv-install.log
 
       - name: Verify installation
         shell: bash
+        run: bash scripts/verify-install.sh "$RUNNER_OS" "$LANGFLOW_VERSION"
+
+      - name: Verify release consistency
+        if: ${{ inputs.release_mode }}
+        shell: bash
         run: |
-          INSTALLED=$(uv run langflow --version 2>/dev/null | awk '/^langflow /{print $2; exit}')
-          echo "Installed: $INSTALLED, Pin: $LANGFLOW_VERSION"
-          if [ -z "$INSTALLED" ] || [ "$INSTALLED" != "$LANGFLOW_VERSION" ]; then
-            echo "::error::Installed version '$INSTALLED' does not match pin '$LANGFLOW_VERSION'"
+          TAG="${GITHUB_REF_NAME#v}"
+          SCRIPT_VER=$(awk -F '"' '/^SCRIPT_VERSION=/{print $2; exit}' src/install-langflow.sh)
+          echo "Tag: $TAG, Script: $SCRIPT_VER"
+          if [ "$TAG" != "$SCRIPT_VER" ]; then
+            echo "::error::Tag $TAG does not match script version $SCRIPT_VER"
             exit 1
-          fi
-          if [ "${{ inputs.release_mode }}" = "true" ]; then
-            TAG="${GITHUB_REF_NAME#v}"
-            SCRIPT_VER=$(awk -F '"' '/^SCRIPT_VERSION=/{print $2; exit}' src/install-langflow.sh)
-            echo "Tag: $TAG, Script: $SCRIPT_VER"
-            if [ "$TAG" != "$SCRIPT_VER" ]; then
-              echo "::error::Tag $TAG does not match script version $SCRIPT_VER"
-              exit 1
-            fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
         run: mise exec -- pwsh -NoProfile -Command "Install-Module PSScriptAnalyzer -Scope CurrentUser -Force"
       - run: bash scripts/verify.sh
 
-  constraint-test:
+  install-test:
     needs: verify
-    uses: ./.github/workflows/constraint-test.yml
+    uses: ./.github/workflows/install-test.yml
     with:
       release_mode: true
 
@@ -36,7 +36,7 @@ jobs:
           path: dist/wheels/litellm-*.whl
 
   package:
-    needs: [verify, constraint-test, litellm-wheel]
+    needs: [verify, install-test, litellm-wheel]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ This repository provides single-click installers for Langflow on Windows, macOS,
 | `scripts/package.ps1` | Cross-platform zip packaging (PowerShell) |
 | `scripts/build-litellm-wheel.sh` | Builds the pinned litellm sdist into a macOS arm64 wheel (CI only) |
 | `.github/workflows/verify.yml` | CI: PR verification (runs `scripts/verify.sh`) |
-| `.github/workflows/constraint-test.yml` | CI: OS-matrix constraint test (win/mac/linux) — validates binary wheels on all platforms before release; a shared reusable workflow (`workflow_call`) consumed by `release.yml` |
-| `.github/workflows/release.yml` | CI: Automated release on tag push (verify + constraint test + package + publish) — calls `constraint-test.yml` as a reusable workflow |
+| `.github/workflows/install-test.yml` | CI: OS-matrix install test (win/mac/linux) — runs the real installer scripts end-to-end without build tools, validating binary wheels and the installer code paths before release; a shared reusable workflow (`workflow_call`) consumed by `release.yml` |
+| `.github/workflows/release.yml` | CI: Automated release on tag push (verify + install test + package + publish) — calls `install-test.yml` as a reusable workflow |
 | `docs/TROUBLESHOOTING.md` | Common issues and fixes |
 | `docs/GATEKEEPER.md` | macOS Gatekeeper bypass guide |
 | `docs/index.html` | Landing page for non-GitHub users (GitHub Pages) — published at `https://nikkisatmaka.github.io/langflow-installer-wrapper/` |
@@ -66,7 +66,7 @@ This repository provides single-click installers for Langflow on Windows, macOS,
 | UTF-8 BOM required on `.ps1` | Windows PowerShell requires UTF-8 with BOM; without it, non-ASCII characters cause parser errors |
 | `uv-install.ps1` fetched at package time | Eliminates `irm \| iex` pattern that heuristic AV triggers on; uses `$PSScriptRoot` to reference local file |
 | Release zip structure | `Install Langflow.bat` and `LICENSE` at zip root; `install-langflow-script.ps1`, `uv-install.ps1`, and `constraints.txt` under `src/` — mirrors repo layout |
-| `--constraint constraints.txt` | Pins only known-breaking transitive deps instead of a full lock file; weekly constraint test CI catches breakage |
+| `--constraint constraints.txt` | Pins only known-breaking transitive deps instead of a full lock file; the weekly install test CI runs the real installer and catches breakage |
 | litellm wheel built at release time | litellm >=1.93 ships a Rust extension (maturin) with no macOS wheels, so `scripts/build-litellm-wheel.sh` builds the pinned version from sdist on a macOS runner and bundles it into the macOS zip; Windows/Linux use the PyPI wheel |
 | Consistent zip name for landing page | `langflow-installer-win.zip` uploaded alongside each versioned zip; landing page download link never needs updating |
 
@@ -156,7 +156,7 @@ Tagging triggers the release workflow automatically:
 9. After merge, push the tag from `main`: `git tag vX.Y.Z && git push origin vX.Y.Z`.
 10. The CI workflow (`.github/workflows/release.yml`):
     - Runs verify checks
-    - Runs OS-matrix constraint test (win-amd64, macos-arm64, linux-x64) with the pinned Langflow version and constraints
+    - Runs the real installer scripts on the OS matrix (win-amd64, macos-arm64, linux-x64) with the pinned Langflow version and constraints
     - Confirms installed version matches the tag and script pin
     - Packages all 3 platform zips (both versioned and unversioned names)
     - Generates release notes from `CHANGELOG.md` via `scripts/release-notes.sh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: run the actual install scripts in CI (replaces the manual uv install in the constraint test)
+
 ## v1.9.1 (2026-08-03)
 
 - fix: pass constraints as separate args to uv on Windows

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,10 +8,10 @@ This repository provides single-click installers for Langflow on Windows, macOS,
 A `constraints.txt` shipped alongside the installer scripts that constrains only the transitive dependencies known to break on certain platforms by shipping source-only releases without pre-built wheels (e.g., litellm, fastapi, cryptography, pypdfium2). Applied via `--constraint` at install time.
 
 **Smoke test**:
-A weekly scheduled CI workflow that runs `uv pip install langflow --constraint src/constraints.txt` on all 3 OS platforms (win-amd64, macos-arm64, linux-x64). If it fails, the constraints file needs updating before the next stable release.
+A scheduled weekly CI workflow that runs the actual installer scripts (`install-langflow.sh` / `install-langflow-script.ps1`) on all 3 OS platforms (win-amd64, macos-arm64, linux-x64) without build tools, then verifies the installed Langflow version and installer artifacts. If it fails, the constraints file needs updating before the next stable release.
 
 **Stable release**:
-A tag `v<LangflowVersion>` (e.g., `v1.11.1`) that pins that exact Langflow version in the installer scripts. The tag-triggered CI runs the full OS-matrix constraint test with the pinned version before packaging and publishing.
+A tag `v<LangflowVersion>` (e.g., `v1.11.1`) that pins that exact Langflow version in the installer scripts. The tag-triggered CI runs the full OS-matrix install test with the pinned version before packaging and publishing.
 
 **Constraint-fix release**:
 A `v<LangflowVersion>-N` postfix when constraints need updating between Langflow versions (e.g., `v1.11.1-1`).

--- a/docs/adr/0003-install-script-test-ci.md
+++ b/docs/adr/0003-install-script-test-ci.md
@@ -1,0 +1,27 @@
+# 0003: Install-script smoke test in CI
+
+**Status:** Accepted.
+
+## Context
+
+ADR 0002 introduced constraint-test CI: a 3-OS matrix job that removed build tools and ran `uv pip install langflow --constraint src/constraints.txt` to validate that binary wheels exist for every dependency. It never executed the installer scripts themselves.
+
+In v1.9.1, the Windows installer regressed: `install-langflow-script.ps1` built `uv pip install ... --constraint C:\...\constraints.txt` as a single token, which clap rejected, so every Windows install failed and bounced back to the menu. The constraint test passed because it invoked uv with correctly separated bash arguments. The test that would have caught this — running the actual installer — did not exist.
+
+## Decision
+
+Fold the installer scripts into the existing 3-OS matrix job (renamed `install-test.yml`):
+
+- Replace the manual `uv venv` + `uv pip install` step with running the real installer end-to-end, driving the menu non-interactively by piping `I` (install path) into `src/install-langflow.sh` on macOS/Linux and `src/install-langflow-script.ps1` (via `powershell.exe`, matching the `.bat` launcher) on Windows.
+- Keep build-tool removal before the script run, so the wheel-only guarantee from ADR 0002 still holds.
+- Keep the installed-version-equals-pin assertion. The script's "try latest" fallback would otherwise mask a broken pin by succeeding with a newer Langflow; the post-run version check catches that.
+- Add `scripts/verify-install.sh` to assert the venv exists, the installed version matches the pin, and the launcher/stop artifacts were created. Desktop shortcuts are warn-only on Windows (headless runners can lack a Desktop folder) and fatal on macOS/Linux where the runner's Desktop is pre-created.
+
+This is deliberately folded into one workflow rather than a separate one: the script test is a strict superset of the manual-install step it replaces, so CI cost is unchanged.
+
+## Consequences
+
+- The weekly schedule, PR/push triggers, and tag-triggered release gating now exercise the real installer code paths on all three platforms.
+- A regression in the Windows PowerShell argument handling (or any installer logic) fails CI on the next PR instead of shipping to users.
+- `verify-install.sh` is added to the bash lint/syntax check lists in `verify.sh` and `mise.toml`.
+- Manual smoke testing (AGENTS.md "Smoke Testing") still covers what CI cannot: real desktop shortcut launching, browser open, idempotency, and uninstall.

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ shfmt = "3.13.1"
 uv = "0.12.1"
 
 [env]
-BASH_FILES = "src/install-langflow.sh src/stop-langflow.sh scripts/verify.sh scripts/package.sh scripts/build-litellm-wheel.sh 'Install Langflow.sh' 'Stop Langflow.sh'"
+BASH_FILES = "src/install-langflow.sh src/stop-langflow.sh scripts/verify.sh scripts/verify-install.sh scripts/package.sh scripts/build-litellm-wheel.sh 'Install Langflow.sh' 'Stop Langflow.sh'"
 PS_FILES = "src/install-langflow-script.ps1 src/stop-langflow-script.ps1"
 
 [tasks.fmt]

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Verify a real installer run in CI: checks the virtual environment, the
+# installed Langflow version, and the launcher/stop artifacts created by
+# src/install-langflow.sh or src/install-langflow-script.ps1.
+# Run from repo root: bash scripts/verify-install.sh <os> <expected-version>
+#   os: Linux | macOS | Windows (matches $RUNNER_OS)
+set -euo pipefail
+
+OS="$1"
+EXPECTED="$2"
+LANGFLOW_DIR="$HOME/langflow"
+FAILED=0
+
+check() {
+    if [ ! -e "$1" ]; then
+        echo "FAIL: missing $1"
+        FAILED=1
+    fi
+}
+
+warn_check() {
+    if [ ! -e "$1" ]; then
+        echo "WARN: $1 not found (headless runner may lack a Desktop)"
+    fi
+}
+
+if [ ! -f "$LANGFLOW_DIR/.venv/pyvenv.cfg" ]; then
+    echo "FAIL: virtual environment not created at $LANGFLOW_DIR/.venv"
+    exit 1
+fi
+
+INSTALLED=$(cd "$LANGFLOW_DIR" && uv run langflow --version 2>/dev/null | awk '/^langflow /{print $2; exit}') || INSTALLED=""
+echo "Installed: $INSTALLED, Expected: $EXPECTED"
+if [ -z "$INSTALLED" ] || [ "$INSTALLED" != "$EXPECTED" ]; then
+    echo "FAIL: installed version '$INSTALLED' does not match pin '$EXPECTED'"
+    exit 1
+fi
+
+case "$OS" in
+    Windows)
+        check "$LANGFLOW_DIR/run-langflow.bat"
+        check "$LANGFLOW_DIR/stop-langflow.ps1"
+        warn_check "$HOME/Desktop/Langflow Web.lnk"
+        warn_check "$HOME/Desktop/Stop Langflow.lnk"
+        ;;
+    macOS)
+        check "$LANGFLOW_DIR/start-langflow.sh"
+        check "$LANGFLOW_DIR/stop-langflow.sh"
+        check "$HOME/Desktop/Langflow Web.command"
+        check "$HOME/Desktop/Stop Langflow.command"
+        ;;
+    Linux)
+        check "$LANGFLOW_DIR/start-langflow.sh"
+        check "$LANGFLOW_DIR/stop-langflow.sh"
+        check "$HOME/.local/share/applications/langflow.desktop"
+        ;;
+    *)
+        echo "FAIL: unknown OS '$OS' (expected Linux, macOS, or Windows)"
+        exit 1
+        ;;
+esac
+
+if [ "$FAILED" -ne 0 ]; then
+    exit 1
+fi
+echo "OK: install verified (langflow $INSTALLED)"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -27,7 +27,7 @@ pass "shebang"
 
 # ── 2. set -euo pipefail on .sh files ──────────────────────────────────────
 
-for f in Install\ Langflow.sh Stop\ Langflow.sh src/install-langflow.sh src/stop-langflow.sh scripts/verify.sh scripts/package.sh; do
+for f in Install\ Langflow.sh Stop\ Langflow.sh src/install-langflow.sh src/stop-langflow.sh scripts/verify.sh scripts/verify-install.sh scripts/package.sh; do
     [ -f "$f" ] || continue
     if ! grep -q 'set -euo pipefail' "$f" 2>/dev/null; then
         fail "$f: missing 'set -euo pipefail'"
@@ -68,7 +68,7 @@ pass "UTF-8 BOM"
 # ── 6. Executable bit on .command and .sh files ────────────────────────────
 
 for f in Install\ Langflow.command Stop\ Langflow.command \
-    Install\ Langflow.sh Stop\ Langflow.sh src/*.sh scripts/verify.sh scripts/package.sh; do
+    Install\ Langflow.sh Stop\ Langflow.sh src/*.sh scripts/verify.sh scripts/verify-install.sh scripts/package.sh; do
     [ -f "$f" ] || continue
     if [ ! -x "$f" ]; then
         fail "$f: not executable"
@@ -78,7 +78,7 @@ pass "executable bit"
 
 # ── 7. bash syntax check ───────────────────────────────────────────────────
 
-for f in src/install-langflow.sh src/stop-langflow.sh scripts/verify.sh scripts/package.sh; do
+for f in src/install-langflow.sh src/stop-langflow.sh scripts/verify.sh scripts/verify-install.sh scripts/package.sh; do
     [ -f "$f" ] || continue
     if ! bash -n "$f" 2>/dev/null; then
         fail "$f: bash syntax error"


### PR DESCRIPTION
This PR makes CI run the real installer scripts instead of a manual `uv pip install` that mirrored them. The v1.9.1 Windows regression (uv constraint passed as a single token) passed the old constraint test because it invoked uv with correct bash argument separation; the actual PowerShell script was never executed in CI.

Changes:
- Rename `constraint-test.yml` -> `install-test.yml`; the 3-OS matrix job now drives `src/install-langflow.sh` / `src/install-langflow-script.ps1` through the install menu (piped `I`) instead of a manual uv install, keeping the build-tool removal so the wheel-only guarantee still holds.
- Add `scripts/verify-install.sh` to assert the venv exists, the installed version matches the pin, and the launcher/stop artifacts were created (desktop shortcuts warn-only on headless runners).
- Pin uv globally for mise shims so the installer's `cd ~/langflow` + `uv` calls resolve (the shim previously had no config there); cap the run with a 15-min step timeout so a failed install fails fast instead of looping on the menu.
- `release.yml` still gates on this workflow as the reusable `install-test`.

Verified on CI: all three OSes pass end-to-end. I also mutation-tested by temporarily reverting the constraint splat to the v1.9.1 single-token form: the Windows job then failed (`Langflow installation failed`, killed by timeout), confirming the test catches that regression class. macOS/Linux were unaffected.