### PR TITLE
fix: quote Exec and Icon paths in Linux .desktop files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: run the actual install scripts in CI (replaces the manual uv install in the constraint test)
+- fix: quote Exec= and Icon= paths in Linux .desktop files (supports usernames with spaces)
 
 ## v1.9.1 (2026-08-03)
 

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -251,8 +251,8 @@ create_linux_shortcut() {
 [Desktop Entry]
 Name=Langflow Web
 Comment=Langflow AI Platform (http://127.0.0.1:7860)
-Exec=${launcher_path}
-Icon=${icon_path}
+Exec="${launcher_path}"
+Icon="${icon_path}"
 Terminal=true
 Type=Application
 Categories=Development;
@@ -297,7 +297,7 @@ EOF
 [Desktop Entry]
 Name=Stop Langflow
 Comment=Stop the Langflow server
-Exec=${launcher_path}
+Exec="${launcher_path}"
 Terminal=true
 Type=Application
 Categories=Development;


### PR DESCRIPTION
This PR quotes the Exec= and Icon= values in the generated Linux .desktop files so installs work on systems whose username contains a space (e.g. /home/Desi Ratna).

The Windows installer already handles spaced usernames via commit 79f0663; this closes the same gap on Linux.