### PR TITLE
fix: roll back the v1.9.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.9.2 (2026-08-04)
+## Unreleased
 
 - feat: run the actual install scripts in CI (replaces the manual uv install in the constraint test)
 - fix: quote Exec= and Icon= paths in Linux .desktop files (supports usernames with spaces)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - feat: run the actual install scripts in CI (replaces the manual uv install in the constraint test)
 - fix: quote Exec= and Icon= paths in Linux .desktop files (supports usernames with spaces)
-- fix: quote the uv constraint path on Windows (supports usernames with spaces)
 
 ## v1.9.1 (2026-08-03)
 

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -17,7 +17,7 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion   = "1.9.2"
+$ScriptVersion   = "1.9.1"
 $LangflowVersion = "1.11.1"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -152,12 +152,7 @@ function Install-LangflowPackage {
         $installOk = $false
         $constraintsArgs = @()
         if (Test-Path $ConstraintsFile) {
-            if ($PSVersionTable.PSVersion.Major -lt 7) {
-                $constraintsArgs = @('--constraint', "`"$ConstraintsFile`"")
-            }
-            else {
-                $constraintsArgs = @('--constraint', "$ConstraintsFile")
-            }
+            $constraintsArgs = @('--constraint', $ConstraintsFile)
         }
 
         uv pip install "langflow==$LangflowVersion" @constraintsArgs 2>&1 | ForEach-Object { Write-Host "   $_" }

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.9.2"
+SCRIPT_VERSION="1.9.1"
 LANGFLOW_VERSION="1.11.1"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
This PR reverts the v1.9.2 release changes (the Windows constraint-path quoting and the version bump) so main returns to a v1.9.1 baseline while keeping the CI install-test feature and the Linux .desktop quoting fix unreleased.