### PR TITLE
fix: pause on install failure so users can screenshot the error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: run the actual install scripts in CI (replaces the manual uv install in the constraint test)
+- fix: pause on install failure so users can screenshot the error before returning to the menu
 - fix: quote Exec= and Icon= paths in Linux .desktop files (supports usernames with spaces)
 
 ## v1.9.1 (2026-08-03)

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -324,9 +324,9 @@ function Start-Install {
     Write-Info "Starting installation..."
     Write-Host ""
 
-    if (-not (Install-Uv)) { return }
-    if (-not (Install-Python)) { return }
-    if (-not (Install-LangflowPackage)) { return }
+    if (-not (Install-Uv)) { return $false }
+    if (-not (Install-Python)) { return $false }
+    if (-not (Install-LangflowPackage)) { return $false }
     New-DesktopShortcut | Out-Null
     New-DesktopStopShortcut | Out-Null
 
@@ -427,7 +427,14 @@ function Main {
     do {
         $choice = Show-Menu
         switch ($choice) {
-            'I' { Start-Install; Show-Banner }
+            'I' {
+                if (-not (Start-Install)) {
+                    Write-Host ""
+                    Write-Warn "Installation failed. Take a screenshot of this screen if you plan to report the issue."
+                    pause
+                }
+                Show-Banner
+            }
             'U' { Start-Uninstall; Show-Banner }
             'Q' { exit 0 }
             default {

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -442,7 +442,11 @@ main() {
         choice=$(show_menu)
         case "$choice" in
             I)
-                start_install
+                if ! start_install; then
+                    printf "\n"
+                    warn "Installation failed. Take a screenshot of this screen if you plan to report the issue."
+                    read -r -p "$(printf "${C}Press Enter to return to the main menu...${N}")"
+                fi
                 show_banner
                 ;;
             U)


### PR DESCRIPTION
This PR adds a pause on any install failure (uv, python, or langflow package) so the error stays on screen for screenshots before returning to the main menu. Works on Windows, macOS, and Linux.