### PR TITLE
release: v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v1.9.2 (2026-08-04)
 
 - feat: run the actual install scripts in CI (replaces the manual uv install in the constraint test)
 - fix: pause on install failure so users can screenshot the error before returning to the menu

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -17,7 +17,7 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion   = "1.9.1"
+$ScriptVersion   = "1.9.2"
 $LangflowVersion = "1.11.1"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.9.1"
+SCRIPT_VERSION="1.9.2"
 LANGFLOW_VERSION="1.11.1"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
This PR bumps the installer to v1.9.2 for the install-test CI feature and two fixes (pause on install error, Linux .desktop quoting). After merge, tagging v1.9.2 triggers the automated release.