### PR TITLE
feat: use --constraint=path syntax instead of --constraint path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ This repository provides single-click installers for Langflow on Windows, macOS,
 | UTF-8 BOM required on `.ps1` | Windows PowerShell requires UTF-8 with BOM; without it, non-ASCII characters cause parser errors |
 | `uv-install.ps1` fetched at package time | Eliminates `irm \| iex` pattern that heuristic AV triggers on; uses `$PSScriptRoot` to reference local file |
 | Release zip structure | `Install Langflow.bat` and `LICENSE` at zip root; `install-langflow-script.ps1`, `uv-install.ps1`, and `constraints.txt` under `src/` — mirrors repo layout |
-| `--constraint constraints.txt` | Pins only known-breaking transitive deps instead of a full lock file; the weekly install test CI runs the real installer and catches breakage |
+| `--constraint=constraints.txt` | Pins only known-breaking transitive deps instead of a full lock file; the weekly install test CI runs the real installer and catches breakage |
 | litellm wheel built at release time | litellm >=1.93 ships a Rust extension (maturin) with no macOS wheels, so `scripts/build-litellm-wheel.sh` builds the pinned version from sdist on a macOS runner and bundles it into the macOS zip; Windows/Linux use the PyPI wheel |
 | Consistent zip name for landing page | `langflow-installer-win.zip` uploaded alongside each versioned zip; landing page download link never needs updating |
 
@@ -237,7 +237,7 @@ Smoke tests are automated via CI (weekly schedule + tag triggers). Before releas
 - Test all 3 menu paths: Install, Uninstall, Quit.
 - Confirm Install is idempotent (re-running detects existing components).
 - Confirm the desktop shortcut launches Langflow and the browser opens.
-- Confirm `uv pip install "langflow==X.Y.Z" --constraint src/constraints.txt` succeeds on the pinned Python 3.12.
+- Confirm `uv pip install "langflow==X.Y.Z" --constraint=src/constraints.txt` succeeds on the pinned Python 3.12.
 - Confirm Uninstall removes `%USERPROFILE%\langflow\` and the shortcut, and optionally Python 3.12.
 
 ## Assets

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,7 @@ This repository provides single-click installers for Langflow on Windows, macOS,
 ## Language
 
 **Constraints file**:
-A `constraints.txt` shipped alongside the installer scripts that constrains only the transitive dependencies known to break on certain platforms by shipping source-only releases without pre-built wheels (e.g., litellm, fastapi, cryptography, pypdfium2). Applied via `--constraint` at install time.
+A `constraints.txt` shipped alongside the installer scripts that constrains only the transitive dependencies known to break on certain platforms by shipping source-only releases without pre-built wheels (e.g., litellm, fastapi, cryptography, pypdfium2). Applied via the `--constraint=` flag at install time.
 
 **Smoke test**:
 A scheduled weekly CI workflow that runs the actual installer scripts (`install-langflow.sh` / `install-langflow-script.ps1`) on all 3 OS platforms (win-amd64, macos-arm64, linux-x64) without build tools, then verifies the installed Langflow version and installer artifacts. If it fails, the constraints file needs updating before the next stable release.

--- a/docs/adr/0002-constraints-based-installs.md
+++ b/docs/adr/0002-constraints-based-installs.md
@@ -19,9 +19,9 @@ Meanwhile, the de facto approach of pinning only the Langflow version and a hand
 Replace the pylock approach with:
 
 - **`constraints.txt`:** A flat file pinning only the transitive dependencies known to ship source-only releases without pre-built wheels on our target platforms (win-amd64, macos-arm64, linux-x64).
-- **Constraint test CI** — a scheduled weekly workflow and a tag-triggered release workflow that run `uv pip install langflow --constraint src/constraints.txt` on all 3 OS platforms. If it fails or requires source compilation, the constraints file needs updating.
+- **Constraint test CI** — a scheduled weekly workflow and a tag-triggered release workflow that run `uv pip install langflow --constraint=src/constraints.txt` on all 3 OS platforms. If it fails or requires source compilation, the constraints file needs updating.
 
-The installer script pins `langflow==X.Y.Z` and applies `--constraint constraints.txt`. Users still run `uv pip install langflow` (with the pin and constraint), and resolution happens at install time — but within the bounds set by the constraints file.
+The installer script pins `langflow==X.Y.Z` and applies `--constraint=constraints.txt`. Users still run `uv pip install langflow` (with the pin and constraint), and resolution happens at install time — but within the bounds set by the constraints file.
 
 ## Consequences
 

--- a/docs/adr/0003-install-script-test-ci.md
+++ b/docs/adr/0003-install-script-test-ci.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-ADR 0002 introduced constraint-test CI: a 3-OS matrix job that removed build tools and ran `uv pip install langflow --constraint src/constraints.txt` to validate that binary wheels exist for every dependency. It never executed the installer scripts themselves.
+ADR 0002 introduced constraint-test CI: a 3-OS matrix job that removed build tools and ran `uv pip install langflow --constraint=src/constraints.txt` to validate that binary wheels exist for every dependency. It never executed the installer scripts themselves.
 
 In v1.9.1, the Windows installer regressed: `install-langflow-script.ps1` built `uv pip install ... --constraint C:\...\constraints.txt` as a single token, which clap rejected, so every Windows install failed and bounced back to the menu. The constraint test passed because it invoked uv with correctly separated bash arguments. The test that would have caught this — running the actual installer — did not exist.
 

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -152,7 +152,7 @@ function Install-LangflowPackage {
         $installOk = $false
         $constraintsArgs = @()
         if (Test-Path $ConstraintsFile) {
-            $constraintsArgs = @('--constraint', $ConstraintsFile)
+            $constraintsArgs = @("--constraint=$ConstraintsFile")
         }
 
         uv pip install "langflow==$LangflowVersion" @constraintsArgs 2>&1 | ForEach-Object { Write-Host "   $_" }

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -152,7 +152,7 @@ install_langflow_package() {
 
     install_ok=false
     constraints_args=()
-    [ -f "$CONSTRAINTS_FILE" ] && constraints_args=("--constraint" "$CONSTRAINTS_FILE")
+    [ -f "$CONSTRAINTS_FILE" ] && constraints_args=("--constraint=$CONSTRAINTS_FILE")
 
     if uv pip install "langflow==${LANGFLOW_VERSION}" "${constraints_args[@]}" 2>&1; then
         install_ok=true


### PR DESCRIPTION
Switch from space-separated  to equals-separated  syntax in both installer scripts and documentation.

This eliminates the spacing ambiguity that caused the v1.9.1 Windows regression (documented in ADR 0003), where  was parsed as a single token by clap, causing every Windows install to fail.

Changes:
- `src/install-langflow-script.ps1`: `@('--constraint', $ConstraintsFile)` → `@(--constraint=$ConstraintsFile)`
- `src/install-langflow.sh`: `(--constraint $CONSTRAINTS_FILE)` → `(--constraint=$CONSTRAINTS_FILE)`
- Updated AGENTS.md, CONTEXT.md, and ADR docs for consistency