### PR TITLE
release: bump version to v1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.9.3 (2026-08-04)
+
+- fix: handle spaces in paths on Windows
+
 ## v1.9.2 (2026-08-04)
 
 - feat: run the actual install scripts in CI (replaces the manual uv install in the constraint test)

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -17,7 +17,7 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion   = "1.9.2"
+$ScriptVersion   = "1.9.3"
 $LangflowVersion = "1.11.1"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.9.2"
+SCRIPT_VERSION="1.9.3"
 LANGFLOW_VERSION="1.11.1"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
Bumps the installer script version from v1.9.2 to v1.9.3.

- Update `$ScriptVersion` / `SCRIPT_VERSION` to 1.9.3
- Add CHANGELOG entry for v1.9.3 (fix: handle spaces in paths on Windows)