### PR TITLE
feat: upgrade Langflow to 1.11.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This repository provides single-click installers for Langflow on Windows, macOS, and Linux using `uv` as the package manager. Python 3.12 is pinned. Langflow is pinned to version **1.11.1**.
+This repository provides single-click installers for Langflow on Windows, macOS, and Linux using `uv` as the package manager. Python 3.12 is pinned. Langflow is pinned to version **1.11.2**.
 
 **Author**: Nikki Satmaka
 - GitHub: https://github.com/NikkiSatmaka/
@@ -50,7 +50,7 @@ This repository provides single-click installers for Langflow on Windows, macOS,
 - **Idempotent** — safe to re-run; checks before acting
 - **User-prompted** — script asks Install / Uninstall / Quit at startup
 - **Credits banner** — GitHub + LinkedIn displayed on every run (Chris Titus style)
-- **Version pinned** — Langflow `==1.11.1`; do not change without updating CONTRACT.md
+- **Version pinned** — Langflow `==1.11.2`; do not change without updating CONTRACT.md
 - **Cross-platform** — Windows (PowerShell), macOS, and Linux (bash); platform-specific logic with shared installer flow
 - **Python pinned** — 3.12 via `uv python install 3.12` (only version with pre-built wheels for all C-extensions on Windows; 3.13+ requires MSVC not available to most users)
 
@@ -123,7 +123,7 @@ Branch from `main`, open a PR, squash merge, delete branch. Keep branches short-
 1. Create a feature branch from `main` with a semantic name.
 2. Make atomic commits with conventional commit messages.
 3. Open a PR against `main`. Use a draft PR if the work is in progress.
-4. PR title format: `<type>: <short description>` (e.g., `feat: upgrade Langflow to 1.11.1`).
+4. PR title format: `<type>: <short description>` (e.g., `feat: upgrade Langflow to 1.11.2`).
 5. PR description should explain **what** and **why**, not **how**.
 6. Self-review the diff before marking the PR ready.
 7. The user reviews, approves, and **squash merges** into `main` — this keeps main history linear and atomic.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,13 +11,13 @@ A `constraints.txt` shipped alongside the installer scripts that constrains only
 A scheduled weekly CI workflow that runs the actual installer scripts (`install-langflow.sh` / `install-langflow-script.ps1`) on all 3 OS platforms (win-amd64, macos-arm64, linux-x64) without build tools, then verifies the installed Langflow version and installer artifacts. If it fails, the constraints file needs updating before the next stable release.
 
 **Stable release**:
-A tag `v<LangflowVersion>` (e.g., `v1.11.1`) that pins that exact Langflow version in the installer scripts. The tag-triggered CI runs the full OS-matrix install test with the pinned version before packaging and publishing.
+A tag `v<LangflowVersion>` (e.g., `v1.11.2`) that pins that exact Langflow version in the installer scripts. The tag-triggered CI runs the full OS-matrix install test with the pinned version before packaging and publishing.
 
 **Constraint-fix release**:
-A `v<LangflowVersion>-N` postfix when constraints need updating between Langflow versions (e.g., `v1.11.1-1`).
+A `v<LangflowVersion>-N` postfix when constraints need updating between Langflow versions (e.g., `v1.11.2-1`).
 
 **Langflow version**:
-The upstream Langflow package version pinned in the installer scripts (e.g., `1.11.1`). Changed manually when a new Langflow version is tested and released.
+The upstream Langflow package version pinned in the installer scripts (e.g., `1.11.2`). Changed manually when a new Langflow version is tested and released.
 
 **Installer wrapper version**:
 The version of this repository's releases (e.g., `v1.9.0`), tracked in the CHANGELOG and used for GitHub Releases and zip filenames. Distinct from the upstream Langflow version.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -2,7 +2,7 @@
 
 ## 1. Purpose
 
-Provide a single-click (or double-click) solution for users to install, run, and uninstall Langflow (`==1.11.1`) using `uv` as the package manager on Windows, macOS, and Linux — with no administrative privileges required on any platform.
+Provide a single-click (or double-click) solution for users to install, run, and uninstall Langflow (`==1.11.2`) using `uv` as the package manager on Windows, macOS, and Linux — with no administrative privileges required on any platform.
 
 ## 2. Credits & Attribution
 
@@ -70,7 +70,7 @@ Run when the user selects `[I]`.
    - **macOS/Linux**: `~/langflow/`
 2. `cd` into the langflow directory.
 3. Create venv: `uv venv` (creates `.venv`).
-4. Install Langflow: `uv pip install langflow==1.11.1`.
+4. Install Langflow: `uv pip install langflow==1.11.2`.
    - If the pin fails (e.g., version yanked), catch the error and suggest `uv pip install langflow` without the pin as a fallback.
 
 ### 5.4 Desktop Shortcuts
@@ -96,7 +96,7 @@ All platforms also create a launcher script in the langflow directory:
 Print a platform-appropriate success summary:
 
 ```
-✓ Langflow 1.11.1 installed
+✓ Langflow 1.11.2 installed
 ✓ Desktop shortcut created: <path>
 ➜ Double-click the shortcut to start Langflow
 ➜ Browser opens automatically at http://127.0.0.1:7860
@@ -144,7 +144,7 @@ Run when the user selects `[U]`.
 | PATH not refreshed after uv install | Read permanent PATH explicitly; on macOS/Linux add to `~/.profile` and re-source |
 | Langflow download is large (~300MB) | Stream uv pip output; print "This may take a few minutes..." beforehand |
 | Port 7860 conflict | Document in completion message; user can configure via `.env` |
-| langflow==1.11.1 yanked on PyPI | Catch the pip error and suggest removing the version pin |
+| langflow==1.11.2 yanked on PyPI | Catch the pip error and suggest removing the version pin |
 | WScript.Shell missing on N/KN editions (Windows) | Catch COM error and print manual shortcut instructions |
 | Antivirus flags `irm \| iex` pattern (Windows) | Fetch `uv-install.ps1` from upstream at package time and include in release zip; invoke via `& "$PSScriptRoot\uv-install.ps1"` instead of downloading at runtime |
 | uv binary not on PATH after install | Explicitly add to PATH in script |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Langflow Installer
 
-One-click installer for [Langflow](https://github.com/langflow-ai/langflow) **1.11.1** on Windows, macOS, and Linux — no admin rights required.
+One-click installer for [Langflow](https://github.com/langflow-ai/langflow) **1.11.2** on Windows, macOS, and Linux — no admin rights required.
 
 [![GitHub](https://img.shields.io/badge/GitHub-NikkiSatmaka-181717?style=for-the-badge&logo=github)](https://github.com/NikkiSatmaka/)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-nikkisatmaka-0A66C2?style=for-the-badge&logo=linkedin)](https://linkedin.com/in/nikkisatmaka/)
@@ -26,7 +26,7 @@ The script will:
 - Install `uv` (self-bootstrapping package manager)
 - Download Python 3.12
 - Create a virtual environment in `%USERPROFILE%\langflow\`
-- Install Langflow 1.11.1
+- Install Langflow 1.11.2
 - Create desktop shortcuts (`Langflow Web.lnk` and `Stop Langflow.lnk`)
 
 After install, double-click the **Langflow Web** desktop shortcut. A terminal window will open, and your browser will launch automatically once the server is ready at `http://127.0.0.1:7860`. To stop the server, double-click **Stop Langflow**.
@@ -45,7 +45,7 @@ The script will:
 - Install `uv` (self-bootstrapping package manager)
 - Download Python 3.12
 - Create a virtual environment in `~/langflow/`
-- Install Langflow 1.11.1
+- Install Langflow 1.11.2
 - Create desktop shortcuts (`Langflow Web.command` and `Stop Langflow.command`)
 
 After install, double-click the **Langflow Web** desktop shortcut. Terminal will open, start the server, and open your browser automatically. To stop the server, double-click **Stop Langflow**.
@@ -60,7 +60,7 @@ The script will:
 - Install `uv` (self-bootstrapping package manager)
 - Download Python 3.12
 - Create a virtual environment in `~/langflow/`
-- Install Langflow 1.11.1
+- Install Langflow 1.11.2
 - Create desktop shortcuts in your app menu and on your desktop (for both starting and stopping Langflow)
 
 After install, launch **Langflow Web** from your app menu or desktop shortcut. A terminal will open, start the server, and open your browser automatically. To stop the server, find **Stop Langflow** in your app menu or desktop.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -35,7 +35,7 @@ The first time you double-click `Install Langflow.command` (or the desktop short
 
 ## Install fails on an Intel (x86_64) Mac
 
-The installer bundles a pre-built `litellm` wheel for Apple Silicon (arm64) only. Langflow 1.11.1 requires `litellm>=1.93`, which publishes no macOS wheels, so on Intel Macs the install must compile it from source and fails if Xcode Command Line Tools and Rust are not installed.
+The installer bundles a pre-built `litellm` wheel for Apple Silicon (arm64) only. Langflow 1.11.2 requires `litellm>=1.93`, which publishes no macOS wheels, so on Intel Macs the install must compile it from source and fails if Xcode Command Line Tools and Rust are not installed.
 
 **To fix:** install Xcode Command Line Tools and Rust, then re-run the installer:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -135,7 +135,7 @@
     <div class="hero">
       <span class="badge">No admin rights required</span>
       <h1>Langflow Web for Windows, macOS, and Linux</h1>
-      <p>Install Langflow Web 1.11.1 with one click. No Python or package manager needed.</p>
+      <p>Install Langflow Web 1.11.2 with one click. No Python or package manager needed.</p>
       <iframe src="https://ghbtns.com/github-btn.html?user=NikkiSatmaka&repo=langflow-installer-wrapper&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160" height="30" title="GitHub" style="margin-top: 1rem;"></iframe>
     </div>
 
@@ -192,7 +192,7 @@
         <li>Installs <strong>uv</strong> (a fast Python package manager)</li>
         <li>Downloads <strong>Python 3.12</strong></li>
         <li>Creates a virtual environment in <code>%USERPROFILE%\langflow\</code></li>
-        <li>Installs <strong>Langflow 1.11.1</strong></li>
+        <li>Installs <strong>Langflow 1.11.2</strong></li>
         <li>Creates <strong>desktop shortcuts</strong> (<em>Langflow Web.lnk</em> and <em>Stop Langflow.lnk</em>)</li>
         <li>Adds the <strong>Langflow icon</strong> to the launch shortcut</li>
       </ul>
@@ -270,7 +270,7 @@
         <li>Installs <strong>uv</strong> (a fast Python package manager)</li>
         <li>Downloads <strong>Python 3.12</strong></li>
         <li>Creates a virtual environment in <code>~/langflow/</code></li>
-        <li>Installs <strong>Langflow 1.11.1</strong></li>
+        <li>Installs <strong>Langflow 1.11.2</strong></li>
         <li>Creates <strong>desktop shortcuts</strong> (<em>Langflow Web.command</em> and <em>Stop Langflow.command</em>)</li>
       </ul>
 
@@ -331,7 +331,7 @@
         <li>Installs <strong>uv</strong> (a fast Python package manager)</li>
         <li>Downloads <strong>Python 3.12</strong></li>
         <li>Creates a virtual environment in <code>~/langflow/</code></li>
-        <li>Installs <strong>Langflow 1.11.1</strong></li>
+        <li>Installs <strong>Langflow 1.11.2</strong></li>
         <li>Creates <strong>desktop shortcuts</strong> in your app menu and on your desktop for both starting and stopping Langflow</li>
         <li>Adds the <strong>Langflow icon</strong> to the launch shortcut</li>
       </ul>

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -168,7 +168,7 @@ function Install-LangflowPackage {
         }
 
         if (-not $installOk) {
-            Write-Fail "Langflow installation failed. Check your internet connection and try again."
+            Write-Fail "Langflow installation failed. Please report the issue at https://github.com/NikkiSatmaka/langflow-installer-wrapper/issues"
             return $false
         }
 

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -3,7 +3,7 @@
     Install or uninstall Langflow on Windows using uv.
 .DESCRIPTION
     Bootstraps uv, installs Python 3.12, creates a virtual environment,
-    installs Langflow 1.11.1, and creates a desktop shortcut.
+    installs Langflow 1.11.2, and creates a desktop shortcut.
     Also supports clean uninstall of all components.
 .NOTES
     Author: Nikki Satmaka
@@ -18,7 +18,7 @@
 param()
 
 $ScriptVersion   = "1.9.3"
-$LangflowVersion = "1.11.1"
+$LangflowVersion = "1.11.2"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"
 $UvBinDir        = "$env:USERPROFILE\.local\bin"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -2,7 +2,7 @@
 #
 # Install or uninstall Langflow on macOS/Linux using uv.
 # Bootstraps uv, installs Python 3.12, creates a virtual environment,
-# installs Langflow 1.11.1, and creates a desktop shortcut.
+# installs Langflow 1.11.2, and creates a desktop shortcut.
 # Also supports clean uninstall of all components.
 #
 # Author: Nikki Satmaka
@@ -13,7 +13,7 @@ set -euo pipefail
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
 SCRIPT_VERSION="1.9.3"
-LANGFLOW_VERSION="1.11.1"
+LANGFLOW_VERSION="1.11.2"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"
 UV_BIN_DIR="$HOME/.local/bin"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -164,7 +164,7 @@ install_langflow_package() {
     fi
 
     if [ "$install_ok" = false ]; then
-        fail "Langflow installation failed. Check your internet connection and try again."
+        fail "Langflow installation failed. Please report the issue at https://github.com/NikkiSatmaka/langflow-installer-wrapper/issues"
         popd >/dev/null || true
         return 1
     fi


### PR DESCRIPTION
This PR upgrades the pinned Langflow version from 1.11.1 to 1.11.2 across the installer scripts and docs.

1.11.2 is a patch release over 1.11.1 with ~45 bug fixes and security hardening (SSRF policy, runtime code-execution policy, MCP/runflow authorization). The dependency delta is minimal and verified against PyPI metadata: only langflow-base (0.11.1 to 0.11.2) and lfx (1.11.1 to 1.11.2) bump; the litellm range (>=1.93,<2.0) is unchanged, so src/constraints.txt and the bundled macOS wheel stay valid. Python 3.12 pin still satisfies the >=3.10,<3.15 requirement.

Also improves the install failure error message in both installers to point users to the issue tracker instead of implying a network problem.