### PR TITLE
release: bump version to v1.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.9.4 (2026-08-05)
+
+- feat: upgrade Langflow to 1.11.2
+- fix: improve install failure error message to point to issue tracker
+
 ## v1.9.3 (2026-08-04)
 
 - fix: handle spaces in paths on Windows

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -17,7 +17,7 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion   = "1.9.3"
+$ScriptVersion   = "1.9.4"
 $LangflowVersion = "1.11.2"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.9.3"
+SCRIPT_VERSION="1.9.4"
 LANGFLOW_VERSION="1.11.2"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
Bumps ScriptVersion/SCRIPT_VERSION to 1.9.4 and updates CHANGELOG.md with entries since v1.9.3.

Changes since v1.9.3:
- feat: upgrade Langflow to 1.11.2
- fix: improve install failure error message to point to issue tracker