### PR TITLE
fix: pass uv constraints by a space-free relative name

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -109,9 +109,16 @@ jobs:
         run: |
           mkdir -p "$HOME/Desktop"
           if [ "$RUNNER_OS" = "Windows" ]; then
-            printf 'I\n\n' | powershell.exe -NoProfile -ExecutionPolicy Bypass -File src/install-langflow-script.ps1
+            SPACED_DIR="$RUNNER_TEMP/Langflow Installer"
           else
-            printf 'I\n\n' | bash src/install-langflow.sh
+            SPACED_DIR="$HOME/Langflow Installer"
+          fi
+          mkdir -p "$SPACED_DIR"
+          cp -r src "$SPACED_DIR/src"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            printf 'I\n\n' | powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$SPACED_DIR/src/install-langflow-script.ps1"
+          else
+            printf 'I\n\n' | bash "$SPACED_DIR/src/install-langflow.sh"
           fi
 
       - name: Verify installation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ This repository provides single-click installers for Langflow on Windows, macOS,
 | UTF-8 BOM required on `.ps1` | Windows PowerShell requires UTF-8 with BOM; without it, non-ASCII characters cause parser errors |
 | `uv-install.ps1` fetched at package time | Eliminates `irm \| iex` pattern that heuristic AV triggers on; uses `$PSScriptRoot` to reference local file |
 | Release zip structure | `Install Langflow.bat` and `LICENSE` at zip root; `install-langflow-script.ps1`, `uv-install.ps1`, and `constraints.txt` under `src/` — mirrors repo layout |
-| `--constraint=constraints.txt` | Pins only known-breaking transitive deps instead of a full lock file; the weekly install test CI runs the real installer and catches breakage |
+| Constraint applied by a relative, space-free name | Pins only known-breaking transitive deps instead of a full lock file. uv re-splits `--constraint`/`-c`/`--override`/`-r` values on whitespace (astral-sh/uv#12639), so a shell-quoted path with a space still truncates; installers copy `constraints.txt` into the langflow dir and pass `--constraint=constraints.txt`. See `docs/adr/0004-uv-constraint-space-free-path.md` |
 | litellm wheel built at release time | litellm >=1.93 ships a Rust extension (maturin) with no macOS wheels, so `scripts/build-litellm-wheel.sh` builds the pinned version from sdist on a macOS runner and bundles it into the macOS zip; Windows/Linux use the PyPI wheel |
 | Consistent zip name for landing page | `langflow-installer-win.zip` uploaded alongside each versioned zip; landing page download link never needs updating |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.9.5 (2026-08-07)
+
+- fix: pass the uv constraints file by a space-free relative name (uv truncates `--constraint` paths on whitespace, astral-sh/uv#12639; previously broke installs on profiles with spaces in the path)
+- ci: run the real installer from a directory containing a space to regression-test constraint handling
+
 ## v1.9.4 (2026-08-05)
 
 - feat: upgrade Langflow to 1.11.2

--- a/docs/adr/0004-uv-constraint-space-free-path.md
+++ b/docs/adr/0004-uv-constraint-space-free-path.md
@@ -1,0 +1,38 @@
+# 0004: Pass uv the constraints file by a space-free relative name
+
+**Status:** Accepted.
+
+## Context
+
+The installer applies `constraints.txt` with `uv pip install langflow --constraint=<path>`. On Windows machines whose user profile path contains a space (e.g. `C:\Users\John Doe\langflow`), uv reported the constraint file as not found: the path appeared truncated at the first space.
+
+This is not a shell quoting problem. Windows PowerShell 5.1 (the runtime used by `Install Langflow.bat`) quotes native-command arguments containing spaces when it builds the command line, and argument array splatting preserves each element as a single token. The prior fixes (v1.9.1 separate-argument splat, the v1.9.2 quoted-path attempt, and the current `--constraint=path` equals form) all assumed the argument was not reaching uv intact.
+
+uv itself re-splits the value of `--constraint`/`-c`/`--override`/`-r` on whitespace (pip's `PIP_CONSTRAINT` list semantics), then truncates a single path at the first space. This was reproduced against the project's pinned uv 0.12.1:
+
+```
+$ uv pip install pytest --constraint="/tmp/opencode/uv space test/constraints file.txt"
+error: File not found: `/tmp/opencode/uv`
+```
+
+The bug is tracked upstream as astral-sh/uv#12639 and remains open. Because the truncation happens inside uv, after the argument is already correctly quoted, no amount of shell-level quoting can fix it.
+
+CI did not catch this: GitHub runner home/checkout paths are space-free, so the real-installer run in `install-test.yml` never exercised a spaced constraint path.
+
+## Decision
+
+Give uv a constraint path whose argument value contains no whitespace, by copying the bundled `constraints.txt` into the langflow working directory and passing the relative name:
+
+- `install-langflow-script.ps1`: `Copy-Item $ConstraintsFile "$LangflowDir\constraints.txt" -Force`, then `uv pip install ... --constraint=constraints.txt` with CWD set to `$LangflowDir` (already pushed before install).
+- `install-langflow.sh`: `cp -f "$CONSTRAINTS_FILE" "$LANGFLOW_DIR/constraints.txt"`, then the same relative argument.
+
+The relative name is space-free, so uv never parses a spaced path. The file on disk may still live under a spaced directory (`%USERPROFILE%\langflow`); uv joins the relative name to the CWD with OS path APIs after the whitespace split, so spaced directories are handled correctly. This was verified by running uv from a directory whose path contained spaces.
+
+The copy is unconditional and idempotent, and the file is removed with the rest of the langflow directory on uninstall.
+
+## Consequences
+
+- The constraints mechanism works on Windows and macOS/Linux regardless of spaces in the user profile or installation directory.
+- `install-test.yml` now runs the real installer from a directory containing a space on all three platforms, so a future uv change to constraint parsing (or a regression to an absolute-path argument) fails CI.
+- `scripts/verify-install.sh` asserts `constraints.txt` exists in the langflow directory after install.
+- The `--constraint=constraints.txt` wording in AGENTS.md and the smoke test instructions remains accurate; only the mechanism for staging the file changed.

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -30,6 +30,8 @@ if [ ! -f "$LANGFLOW_DIR/.venv/pyvenv.cfg" ]; then
     exit 1
 fi
 
+check "$LANGFLOW_DIR/constraints.txt"
+
 INSTALLED=$(cd "$LANGFLOW_DIR" && uv run langflow --version 2>/dev/null | awk '/^langflow /{print $2; exit}') || INSTALLED=""
 echo "Installed: $INSTALLED, Expected: $EXPECTED"
 if [ -z "$INSTALLED" ] || [ "$INSTALLED" != "$EXPECTED" ]; then

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -17,7 +17,7 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion   = "1.9.4"
+$ScriptVersion   = "1.9.5"
 $LangflowVersion = "1.11.2"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"
@@ -152,7 +152,8 @@ function Install-LangflowPackage {
         $installOk = $false
         $constraintsArgs = @()
         if (Test-Path $ConstraintsFile) {
-            $constraintsArgs = @("--constraint=$ConstraintsFile")
+            Copy-Item -Path $ConstraintsFile -Destination "$LangflowDir\constraints.txt" -Force
+            $constraintsArgs = @("--constraint=constraints.txt")
         }
 
         uv pip install "langflow==$LangflowVersion" @constraintsArgs 2>&1 | ForEach-Object { Write-Host "   $_" }

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.9.4"
+SCRIPT_VERSION="1.9.5"
 LANGFLOW_VERSION="1.11.2"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"
@@ -152,7 +152,10 @@ install_langflow_package() {
 
     install_ok=false
     constraints_args=()
-    [ -f "$CONSTRAINTS_FILE" ] && constraints_args=("--constraint=$CONSTRAINTS_FILE")
+    if [ -f "$CONSTRAINTS_FILE" ]; then
+        cp -f "$CONSTRAINTS_FILE" "$LANGFLOW_DIR/constraints.txt"
+        constraints_args=("--constraint=constraints.txt")
+    fi
 
     if uv pip install "langflow==${LANGFLOW_VERSION}" "${constraints_args[@]}" 2>&1; then
         install_ok=true


### PR DESCRIPTION
This PR fixes installs breaking when the constraint file path contains a space. uv re-splits `--constraint`/`-c`/`--override`/`-r` values on whitespace (astral-sh/uv#12639), so the path truncates at the first space even when shell-quoted correctly. The installers now copy `constraints.txt` into the langflow dir and pass the relative name `--constraint=constraints.txt`, and CI runs the real installer from a directory containing a space so the bug can't regress.