### PR TITLE
fix: friendlier first-launch wait messages in server launchers

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -64,3 +64,12 @@ Corrupted cache or stale data can cause Langflow to fail on startup or act unexp
 - **Linux**: Delete `~/.cache/langflow` (or run `rm -rf ~/.cache/langflow`)
 
 Then start Langflow again from the desktop shortcut. Your installed packages stay in place — only cached data is removed.
+
+## Browser says the site can't be reached on first launch
+
+First launch takes a few minutes while Langflow loads everything it needs. This is normal — the launcher window keeps you updated, and your browser opens by itself when the server is ready. You don't need to open `http://127.0.0.1:7860` manually while the launcher still shows status updates.
+
+If several minutes have passed and no browser opened:
+1. Check the launcher window for the latest status line
+2. Visit <http://127.0.0.1:7860> manually
+3. If it still doesn't load, check the minimized server window (Windows) or `/tmp/langflow-server.log` (macOS/Linux) for errors

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -223,11 +223,11 @@ echo Starting Langflow server...
 start /MIN "Langflow Server - KEEP OPEN" "$uvPath" run langflow run
 echo.
 echo  +==================================================+
-echo  +  First launch can take a few minutes.            +
-echo  +  That is completely normal, please be patient.   +
+echo  +  Starting Langflow can take up to 10-15          +
+echo  +  minutes on slower computers. This is normal.    +
 echo  +                                                  +
 echo  +  Your browser will open by itself as soon as     +
-echo  +  Langflow is ready.                              +
+echo  +  Langflow is ready at http://127.0.0.1:7860      +
 echo  +                                                  +
 echo  +  Just leave this window open. No action needed.  +
 echo  +==================================================+
@@ -239,13 +239,19 @@ powershell -NoProfile -Command "try { Invoke-WebRequest -Uri 'http://127.0.0.1:7
 if %errorlevel% equ 0 goto serverready
 timeout /t 3 /nobreak >nul
 set /a waited+=3
-set /a tick=%waited% %% 21
-if %tick% neq 0 goto waitloop
+set /a tick21=%waited% %% 21
+set /a tick60=%waited% %% 60
+set SayMsg=
+if %tick21% equ 0 if %waited% lss 64 set SayMsg=1
+if %tick60% equ 0 if %waited% geq 120 set SayMsg=1
+if not defined SayMsg goto waitloop
 if %waited% equ 21 echo Still starting... (%waited% seconds). This is normal on first launch.
 if %waited% equ 42 echo Still starting... (%waited% seconds). First launch takes the longest.
 if %waited% equ 63 echo Still starting... (%waited% seconds). Thanks for your patience.
-if %waited% geq 84 echo Still starting... (%waited% seconds).
-if %waited% geq 84 echo If no browser has opened by now, you can also visit http://127.0.0.1:7860 manually.
+set /a mins=%waited% / 60
+if %waited% geq 120 if %mins% leq 5 echo Still starting... (%mins% min). Slower computers can take several minutes.
+if %waited% geq 120 if %mins% geq 6 echo Still starting... (%mins% min). On older computers first start can take 10-15 minutes.
+if %waited% equ 900 echo Still waiting after 15 minutes? Check the minimized server window for errors.
 goto waitloop
 
 :serverready

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -222,16 +222,30 @@ echo.
 echo Starting Langflow server...
 start /MIN "Langflow Server - KEEP OPEN" "$uvPath" run langflow run
 echo.
-echo Waiting for Langflow to start...
-echo The browser will open automatically when the server is ready.
-echo You can also manually visit http://127.0.0.1:7860 at any time.
+echo  +==================================================+
+echo  +  First launch can take a few minutes.            +
+echo  +  That is completely normal, please be patient.   +
+echo  +                                                  +
+echo  +  Your browser will open by itself as soon as     +
+echo  +  Langflow is ready.                              +
+echo  +                                                  +
+echo  +  Just leave this window open. No action needed.  +
+echo  +==================================================+
 echo.
+set /a waited=0
 
 :waitloop
 powershell -NoProfile -Command "try { Invoke-WebRequest -Uri 'http://127.0.0.1:7860/health_check' -UseBasicParsing -TimeoutSec 3 | Out-Null; exit 0 } catch { exit 1 }"
 if %errorlevel% equ 0 goto serverready
-timeout /t 5 /nobreak >nul
-echo Still waiting... check http://127.0.0.1:7860 in your browser
+timeout /t 3 /nobreak >nul
+set /a waited+=3
+set /a tick=%waited% %% 21
+if %tick% neq 0 goto waitloop
+if %waited% equ 21 echo Still starting... (%waited% seconds). This is normal on first launch.
+if %waited% equ 42 echo Still starting... (%waited% seconds). First launch takes the longest.
+if %waited% equ 63 echo Still starting... (%waited% seconds). Thanks for your patience.
+if %waited% geq 84 echo Still starting... (%waited% seconds).
+if %waited% geq 84 echo If no browser has opened by now, you can also visit http://127.0.0.1:7860 manually.
 goto waitloop
 
 :serverready

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -186,11 +186,11 @@ L_PID=$!
 echo "Server PID: $L_PID"
 echo ""
 echo " +==================================================+"
-echo " +  First launch can take a few minutes.            +"
-echo " +  That is completely normal, please be patient.   +"
+echo " +  Starting Langflow can take up to 10-15          +"
+echo " +  minutes on slower computers. This is normal.    +"
 echo " +                                                  +"
 echo " +  Your browser will open by itself as soon as     +"
-echo " +  Langflow is ready.                              +"
+echo " +  Langflow is ready at http://127.0.0.1:7860      +"
 echo " +                                                  +"
 echo " +  Just leave this window open. No action needed.  +"
 echo " +==================================================+"
@@ -202,17 +202,26 @@ while true; do
     fi
     sleep 3
     waited=$((waited+3))
-    tick=$((waited % 21))
-    [ "$tick" -ne 0 ] && continue
-    case $waited in
-        21) echo "Still starting... (${waited} seconds). This is normal on first launch." ;;
-        42) echo "Still starting... (${waited} seconds). First launch takes the longest." ;;
-        63) echo "Still starting... (${waited} seconds). Thanks for your patience." ;;
-        *)
-            echo "Still starting... (${waited} seconds)."
-            echo "If no browser has opened by now, you can also visit http://127.0.0.1:7860 manually."
-            ;;
-    esac
+    tick21=$((waited % 21))
+    tick60=$((waited % 60))
+    if [ "$tick21" -eq 0 ] && [ "$waited" -lt 64 ]; then
+        case $waited in
+            21) echo "Still starting... (${waited} seconds). This is normal on first launch." ;;
+            42) echo "Still starting... (${waited} seconds). First launch takes the longest." ;;
+            63) echo "Still starting... (${waited} seconds). Thanks for your patience." ;;
+        esac
+    fi
+    if [ "$tick60" -eq 0 ] && [ "$waited" -ge 120 ]; then
+        mins=$((waited / 60))
+        if [ "$mins" -le 5 ]; then
+            echo "Still starting... (${mins} min). Slower computers can take several minutes."
+        else
+            echo "Still starting... (${mins} min). On older computers first start can take 10-15 minutes."
+        fi
+        if [ "$waited" -eq 900 ]; then
+            echo "Still waiting after 15 minutes? Check the server log: tail -f /tmp/langflow-server.log"
+        fi
+    fi
 done
 echo ""
 echo " +==================================================+"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -185,16 +185,34 @@ nohup uv run langflow run > /tmp/langflow-server.log 2>&1 &
 L_PID=$!
 echo "Server PID: $L_PID"
 echo ""
-echo "Waiting for Langflow to start..."
-echo "The browser will open automatically when the server is ready."
-echo "You can also manually visit http://127.0.0.1:7860 at any time."
+echo " +==================================================+"
+echo " +  First launch can take a few minutes.            +"
+echo " +  That is completely normal, please be patient.   +"
+echo " +                                                  +"
+echo " +  Your browser will open by itself as soon as     +"
+echo " +  Langflow is ready.                              +"
+echo " +                                                  +"
+echo " +  Just leave this window open. No action needed.  +"
+echo " +==================================================+"
 echo ""
+waited=0
 while true; do
     if curl -s -o /dev/null --max-time 2 "http://127.0.0.1:7860/health_check" 2>/dev/null; then
         break
     fi
-    echo "Still waiting... check http://127.0.0.1:7860 in your browser"
-    sleep 5
+    sleep 3
+    waited=$((waited+3))
+    tick=$((waited % 21))
+    [ "$tick" -ne 0 ] && continue
+    case $waited in
+        21) echo "Still starting... (${waited} seconds). This is normal on first launch." ;;
+        42) echo "Still starting... (${waited} seconds). First launch takes the longest." ;;
+        63) echo "Still starting... (${waited} seconds). Thanks for your patience." ;;
+        *)
+            echo "Still starting... (${waited} seconds)."
+            echo "If no browser has opened by now, you can also visit http://127.0.0.1:7860 manually."
+            ;;
+    esac
 done
 echo ""
 echo " +==================================================+"


### PR DESCRIPTION
This PR replaces the identical "Still waiting..." line printed every 5 seconds with an upfront reassurance box and varied status updates every ~21 seconds showing elapsed time. The manual URL hint now appears only after 84 seconds, so users no longer open the browser before the server is listening, and adds a troubleshooting entry for the same confusion.

- Both launchers (Windows .bat generated by ps1, macOS/Linux .sh) poll every 3s for prompt browser-open
- Windows launcher stays pure ASCII for `Set-Content -Encoding Ascii`
- Wait-loop cadence verified by simulation; `bash scripts/verify.sh` passes 12/12