### PR TITLE
feat: upgrade Langflow to 1.11.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This repository provides single-click installers for Langflow on Windows, macOS, and Linux using `uv` as the package manager. Python 3.12 is pinned. Langflow is pinned to version **1.11.3**.
+This repository provides single-click installers for Langflow on Windows, macOS, and Linux using `uv` as the package manager. Python 3.12 is pinned. Langflow is pinned to version **1.11.4**.
 
 **Author**: Nikki Satmaka
 - GitHub: https://github.com/NikkiSatmaka/
@@ -49,7 +49,7 @@ This repository provides single-click installers for Langflow on Windows, macOS,
 - **Idempotent** — safe to re-run; checks before acting
 - **User-prompted** — script asks Install / Uninstall / Quit at startup
 - **Credits banner** — GitHub + LinkedIn displayed on every run (Chris Titus style)
-- **Version pinned** — Langflow `==1.11.3`; do not change without updating CONTRACT.md
+- **Version pinned** — Langflow `==1.11.4`; do not change without updating CONTRACT.md
 - **Cross-platform** — Windows (PowerShell), macOS, and Linux (bash); platform-specific logic with shared installer flow
 - **Python pinned** — 3.12 via `uv python install 3.12` (only version with pre-built wheels for all C-extensions on Windows; 3.13+ requires MSVC not available to most users)
 
@@ -121,7 +121,7 @@ Branch from `main`, open a PR, squash merge, delete branch. Keep branches short-
 1. Create a feature branch from `main` with a semantic name.
 2. Make atomic commits with conventional commit messages.
 3. Open a PR against `main`. Use a draft PR if the work is in progress.
-4. PR title format: `<type>: <short description>` (e.g., `feat: upgrade Langflow to 1.11.3`).
+4. PR title format: `<type>: <short description>` (e.g., `feat: upgrade Langflow to 1.11.4`).
 5. PR description should explain **what** and **why**, not **how**.
 6. Self-review the diff before marking the PR ready.
 7. The user reviews, approves, and **squash merges** into `main` — this keeps main history linear and atomic.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -2,7 +2,7 @@
 
 ## 1. Purpose
 
-Provide a single-click (or double-click) solution for users to install, run, and uninstall Langflow (`==1.11.3`) using `uv` as the package manager on Windows, macOS, and Linux — with no administrative privileges required on any platform.
+Provide a single-click (or double-click) solution for users to install, run, and uninstall Langflow (`==1.11.4`) using `uv` as the package manager on Windows, macOS, and Linux — with no administrative privileges required on any platform.
 
 ## 2. Credits & Attribution
 
@@ -70,7 +70,7 @@ Run when the user selects `[I]`.
    - **macOS/Linux**: `~/langflow/`
 2. `cd` into the langflow directory.
 3. Create venv: `uv venv` (creates `.venv`).
-4. Install Langflow: `uv pip install langflow==1.11.3`.
+4. Install Langflow: `uv pip install langflow==1.11.4`.
    - If the pin fails (e.g., version yanked), catch the error and suggest `uv pip install langflow` without the pin as a fallback.
 
 ### 5.4 Desktop Shortcuts
@@ -96,7 +96,7 @@ All platforms also create a launcher script in the langflow directory:
 Print a platform-appropriate success summary:
 
 ```
-✓ Langflow 1.11.3 installed
+✓ Langflow 1.11.4 installed
 ✓ Desktop shortcut created: <path>
 ➜ Double-click the shortcut to start Langflow
 ➜ Browser opens automatically at http://127.0.0.1:7860
@@ -144,7 +144,7 @@ Run when the user selects `[U]`.
 | PATH not refreshed after uv install | Read permanent PATH explicitly; on macOS/Linux add to `~/.profile` and re-source |
 | Langflow download is large (~300MB) | Stream uv pip output; print "This may take a few minutes..." beforehand |
 | Port 7860 conflict | Document in completion message; user can configure via `.env` |
-| langflow==1.11.3 yanked on PyPI | Catch the pip error and suggest removing the version pin |
+| langflow==1.11.4 yanked on PyPI | Catch the pip error and suggest removing the version pin |
 | WScript.Shell missing on N/KN editions (Windows) | Catch COM error and print manual shortcut instructions |
 | Antivirus flags `irm \| iex` pattern (Windows) | Fetch `uv-install.ps1` from upstream at package time and include in release zip; invoke via `& "$PSScriptRoot\uv-install.ps1"` instead of downloading at runtime |
 | uv binary not on PATH after install | Explicitly add to PATH in script |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Langflow Installer
 
-One-click installer for [Langflow](https://github.com/langflow-ai/langflow) **1.11.3** on Windows, macOS, and Linux — no admin rights required.
+One-click installer for [Langflow](https://github.com/langflow-ai/langflow) **1.11.4** on Windows, macOS, and Linux — no admin rights required.
 
 [![GitHub](https://img.shields.io/badge/GitHub-NikkiSatmaka-181717?style=for-the-badge&logo=github)](https://github.com/NikkiSatmaka/)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-nikkisatmaka-0A66C2?style=for-the-badge&logo=linkedin)](https://linkedin.com/in/nikkisatmaka/)
@@ -26,7 +26,7 @@ The script will:
 - Install `uv` (self-bootstrapping package manager)
 - Download Python 3.12
 - Create a virtual environment in `%USERPROFILE%\langflow\`
-- Install Langflow 1.11.3
+- Install Langflow 1.11.4
 - Create desktop shortcuts (`Langflow Web.lnk` and `Stop Langflow.lnk`)
 
 After install, double-click the **Langflow Web** desktop shortcut. A terminal window will open, and your browser will launch automatically once the server is ready at `http://127.0.0.1:7860`. To stop the server, double-click **Stop Langflow**.
@@ -45,7 +45,7 @@ The script will:
 - Install `uv` (self-bootstrapping package manager)
 - Download Python 3.12
 - Create a virtual environment in `~/langflow/`
-- Install Langflow 1.11.3
+- Install Langflow 1.11.4
 - Create desktop shortcuts (`Langflow Web.command` and `Stop Langflow.command`)
 
 After install, double-click the **Langflow Web** desktop shortcut. Terminal will open, start the server, and open your browser automatically. To stop the server, double-click **Stop Langflow**.
@@ -60,7 +60,7 @@ The script will:
 - Install `uv` (self-bootstrapping package manager)
 - Download Python 3.12
 - Create a virtual environment in `~/langflow/`
-- Install Langflow 1.11.3
+- Install Langflow 1.11.4
 - Create desktop shortcuts in your app menu and on your desktop (for both starting and stopping Langflow)
 
 After install, launch **Langflow Web** from your app menu or desktop shortcut. A terminal will open, start the server, and open your browser automatically. To stop the server, find **Stop Langflow** in your app menu or desktop.

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,12 @@
       font-size: 0.8rem; font-weight: 600; padding: 0.25rem 0.75rem;
       border-radius: 999px; margin-bottom: 1rem;
     }
+    .hero .star-ask { font-size: 0.9rem; margin-top: 0.75rem; }
+    .hero .star-ask a {
+      color: #38bdf8; text-decoration: none;
+      border-bottom: 1px solid transparent; transition: border-color 0.15s;
+    }
+    .hero .star-ask a:hover { border-color: #38bdf8; }
 
     /* Tabs */
     input[name="os"] { display: none; }
@@ -136,6 +142,7 @@
       <span class="badge">No admin rights required</span>
       <h1>Langflow Web for Windows, macOS, and Linux</h1>
       <p>Install Langflow Web 1.11.4 with one click. No Python or package manager needed.</p>
+      <p class="star-ask">If this installer saved you time, please <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/stargazers">leave a star</a> &mdash; it helps others find it.</p>
       <iframe src="https://ghbtns.com/github-btn.html?user=NikkiSatmaka&repo=langflow-installer-wrapper&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160" height="30" title="GitHub" style="margin-top: 1rem;"></iframe>
     </div>
 
@@ -209,8 +216,14 @@
         </div>
         <div class="step">
           <div class="step-num">3</div>
-          <div><strong>Wait for your browser</strong><p>The launcher opens your browser at <code>http://127.0.0.1:7860</code> automatically once Langflow is ready.</p></div>
+          <div><strong>Wait for your browser</strong><p>The launcher prints progress updates every minute while Langflow starts. Your browser then opens by itself at <code>http://127.0.0.1:7860</code> &mdash; no need to open it early.</p></div>
         </div>
+      </div>
+
+      <div class="tip">
+        <strong>&#9203;&#65039; First start takes a while</strong> &mdash;
+        Up to 10&ndash;15 minutes on slower computers is normal.
+        Leave this window open until your browser opens by itself.
       </div>
 
       <h2>How to stop</h2>
@@ -282,12 +295,18 @@
         </div>
         <div class="step">
           <div class="step-num">2</div>
-          <div><strong>Double-click the shortcut</strong><p>Terminal will open, start the server, and automatically open your browser once Langflow is ready at <code>http://127.0.0.1:7860</code>.</p></div>
+          <div><strong>Double-click the shortcut</strong><p>Terminal will open and start the server. Progress updates print every minute, and your browser opens by itself once Langflow is ready at <code>http://127.0.0.1:7860</code>.</p></div>
         </div>
         <div class="step">
           <div class="step-num">3</div>
           <div><strong>Press Enter to dismiss</strong><p>After the browser opens, press Enter in Terminal to close the launcher. The server keeps running in the background.</p></div>
         </div>
+      </div>
+
+      <div class="tip">
+        <strong>&#9203;&#65039; First start takes a while</strong> &mdash;
+        Up to 10&ndash;15 minutes on slower computers is normal.
+        Leave this window open until your browser opens by itself.
       </div>
 
       <h2>How to stop</h2>
@@ -344,12 +363,18 @@
         </div>
         <div class="step">
           <div class="step-num">2</div>
-          <div><strong>Launch Langflow</strong><p>Click the app menu entry or double-click the desktop shortcut. A terminal will open, start the server, and automatically open your browser at <code>http://127.0.0.1:7860</code>.</p></div>
+          <div><strong>Launch Langflow</strong><p>Click the app menu entry or double-click the desktop shortcut. A terminal will open, start the server, print progress updates every minute, and open your browser by itself at <code>http://127.0.0.1:7860</code>.</p></div>
         </div>
         <div class="step">
           <div class="step-num">3</div>
           <div><strong>Press Enter to dismiss</strong><p>After the browser opens, press Enter in the terminal to close it. The server keeps running in the background.</p></div>
         </div>
+      </div>
+
+      <div class="tip">
+        <strong>&#9203;&#65039; First start takes a while</strong> &mdash;
+        Up to 10&ndash;15 minutes on slower computers is normal.
+        Leave this window open until your browser opens by itself.
       </div>
 
       <h2>How to stop</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -135,7 +135,7 @@
     <div class="hero">
       <span class="badge">No admin rights required</span>
       <h1>Langflow Web for Windows, macOS, and Linux</h1>
-      <p>Install Langflow Web 1.11.3 with one click. No Python or package manager needed.</p>
+      <p>Install Langflow Web 1.11.4 with one click. No Python or package manager needed.</p>
       <iframe src="https://ghbtns.com/github-btn.html?user=NikkiSatmaka&repo=langflow-installer-wrapper&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160" height="30" title="GitHub" style="margin-top: 1rem;"></iframe>
     </div>
 
@@ -192,7 +192,7 @@
         <li>Installs <strong>uv</strong> (a fast Python package manager)</li>
         <li>Downloads <strong>Python 3.12</strong></li>
         <li>Creates a virtual environment in <code>%USERPROFILE%\langflow\</code></li>
-        <li>Installs <strong>Langflow 1.11.3</strong></li>
+        <li>Installs <strong>Langflow 1.11.4</strong></li>
         <li>Creates <strong>desktop shortcuts</strong> (<em>Langflow Web.lnk</em> and <em>Stop Langflow.lnk</em>)</li>
         <li>Adds the <strong>Langflow icon</strong> to the launch shortcut</li>
       </ul>
@@ -270,7 +270,7 @@
         <li>Installs <strong>uv</strong> (a fast Python package manager)</li>
         <li>Downloads <strong>Python 3.12</strong></li>
         <li>Creates a virtual environment in <code>~/langflow/</code></li>
-        <li>Installs <strong>Langflow 1.11.3</strong></li>
+        <li>Installs <strong>Langflow 1.11.4</strong></li>
         <li>Creates <strong>desktop shortcuts</strong> (<em>Langflow Web.command</em> and <em>Stop Langflow.command</em>)</li>
       </ul>
 
@@ -331,7 +331,7 @@
         <li>Installs <strong>uv</strong> (a fast Python package manager)</li>
         <li>Downloads <strong>Python 3.12</strong></li>
         <li>Creates a virtual environment in <code>~/langflow/</code></li>
-        <li>Installs <strong>Langflow 1.11.3</strong></li>
+        <li>Installs <strong>Langflow 1.11.4</strong></li>
         <li>Creates <strong>desktop shortcuts</strong> in your app menu and on your desktop for both starting and stopping Langflow</li>
         <li>Adds the <strong>Langflow icon</strong> to the launch shortcut</li>
       </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -98,6 +98,41 @@
     }
     .tip strong { color: #fef08a; }
 
+    /* Common issues card */
+    .issues {
+      background: #1e293b; border: 1px solid #334155; border-radius: 12px;
+      padding: 1.25rem; margin: 0 0 2rem;
+    }
+    .issues-header {
+      display: flex; align-items: center; gap: 0.5rem;
+      font-size: 0.95rem; font-weight: 600; color: #f8fafc; margin-bottom: 0.5rem;
+    }
+    .issues-header svg { width: 16px; height: 16px; fill: #38bdf8; flex-shrink: 0; }
+    .issues ul { list-style: none; padding: 0; margin: 0; }
+    .issues ul li::before { content: "\26A0"; color: #eab308; }
+    .issues ul li { font-size: 0.9rem; }
+    .issues a {
+      color: #38bdf8; text-decoration: none;
+      white-space: nowrap; font-weight: 600;
+    }
+    .issues a:hover { text-decoration: underline; }
+
+    /* Floating help button */
+    .help-fab {
+      position: fixed; bottom: 1.25rem; right: 1.25rem; z-index: 100;
+      display: inline-flex; align-items: center; gap: 0.45rem;
+      background: #1e293b; color: #e2e8f0; font-size: 0.9rem; font-weight: 600;
+      padding: 0.65rem 1.1rem; border-radius: 999px;
+      border: 1px solid #334155; box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+      text-decoration: none; transition: background 0.15s, border-color 0.15s;
+    }
+    .help-fab:hover { background: #334155; border-color: #38bdf8; }
+    .help-fab-icon {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 20px; height: 20px; border-radius: 50%;
+      background: #3b82f6; color: #fff; font-size: 0.8rem; font-weight: 700;
+    }
+
     /* Troubleshooting link */
     .help {
       text-align: center; margin: 2.5rem 0 1.5rem;
@@ -132,6 +167,7 @@
       .hero h1 { font-size: 1.5rem; }
       .download-btn { font-size: 1rem; padding: 0.85rem 2rem; width: 100%; justify-content: center; }
       .tabs { flex-direction: column; align-items: center; }
+      .help-fab { bottom: 0.9rem; right: 0.9rem; padding: 0.55rem 0.9rem; }
     }
   </style>
 </head>
@@ -176,6 +212,17 @@
           Download for Windows
         </a>
         <div class="download-sub">~56 KB &middot; Windows 10 / 11</div>
+      </div>
+
+      <div class="issues">
+        <div class="issues-header">
+          <svg viewBox="0 0 24 24"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"/></svg>
+          Common issues
+        </div>
+        <ul>
+          <li>Installer blocked by Smart App Control or antivirus &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#smart-app-control-blocks-the-installer-windows">Fix &rarr;</a></li>
+          <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch">Fix &rarr;</a></li>
+        </ul>
       </div>
 
       <h2>How to install</h2>
@@ -250,6 +297,17 @@
           Download for macOS
         </a>
         <div class="download-sub">~32 KB &middot; macOS 12+ (Intel &amp; Apple Silicon)</div>
+      </div>
+
+      <div class="issues">
+        <div class="issues-header">
+          <svg viewBox="0 0 24 24"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"/></svg>
+          Common issues
+        </div>
+        <ul>
+          <li>&ldquo;Cannot verify the developer&rdquo; when opening the file &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#macos-security-warning-when-opening-command-file">Fix &rarr;</a></li>
+          <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch">Fix &rarr;</a></li>
+        </ul>
       </div>
 
       <h2>How to install</h2>
@@ -327,6 +385,17 @@
           Download for Linux
         </a>
         <div class="download-sub">~32 KB &middot; Any modern Linux distribution</div>
+      </div>
+
+      <div class="issues">
+        <div class="issues-header">
+          <svg viewBox="0 0 24 24"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"/></svg>
+          Common issues
+        </div>
+        <ul>
+          <li>Double-click opens the file in a text editor &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear">Fix &rarr;</a></li>
+          <li>Langflow Web missing from your app menu or desktop &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear">Fix &rarr;</a></li>
+        </ul>
       </div>
 
       <h2>How to install</h2>
@@ -419,5 +488,11 @@
 
     <footer></footer>
   </div>
+
+  <!-- Floating help button -->
+  <a class="help-fab" href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md">
+    <span class="help-fab-icon">?</span>
+    Need help?
+  </a>
 </body>
 </html>

--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -3,7 +3,7 @@
     Install or uninstall Langflow on Windows using uv.
 .DESCRIPTION
     Bootstraps uv, installs Python 3.12, creates a virtual environment,
-    installs Langflow 1.11.3, and creates a desktop shortcut.
+    installs Langflow 1.11.4, and creates a desktop shortcut.
     Also supports clean uninstall of all components.
 .NOTES
     Author: Nikki Satmaka
@@ -17,8 +17,8 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion   = "1.9.6"
-$LangflowVersion = "1.11.3"
+$ScriptVersion   = "1.9.7"
+$LangflowVersion = "1.11.4"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"
 $UvBinDir        = "$env:USERPROFILE\.local\bin"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -2,7 +2,7 @@
 #
 # Install or uninstall Langflow on macOS/Linux using uv.
 # Bootstraps uv, installs Python 3.12, creates a virtual environment,
-# installs Langflow 1.11.3, and creates a desktop shortcut.
+# installs Langflow 1.11.4, and creates a desktop shortcut.
 # Also supports clean uninstall of all components.
 #
 # Author: Nikki Satmaka
@@ -12,8 +12,8 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.9.6"
-LANGFLOW_VERSION="1.11.3"
+SCRIPT_VERSION="1.9.7"
+LANGFLOW_VERSION="1.11.4"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"
 UV_BIN_DIR="$HOME/.local/bin"


### PR DESCRIPTION
This PR bumps the Langflow pin from 1.11.3 to 1.11.4 and the installer version to 1.9.7, updating all plain-text references across README, CONTRACT.md, AGENTS.md, and the landing page.

1.11.4 is a patch release (MCP SDK backport pin, FastAPI range restore, dependency security floors) with the same pure-Python wheel model and `requires_python` range, so the Python 3.12 pin and empty `constraints.txt` carry over.

It also refreshes the landing page: a hero star ask, run steps that set the 10-15 minute first-start expectation with per-minute progress updates, timing tip boxes per OS tab, an always-visible floating Need-help button, and common-issues cards that deep-link each symptom to its fix in TROUBLESHOOTING.md.

Note: merge #49 first — one deep-linked troubleshooting section (first-launch 'site can't be reached') ships in that PR.