### PR TITLE
docs: open troubleshooting links in a new tab

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -220,8 +220,8 @@
           Common issues
         </div>
         <ul>
-          <li>Installer blocked by Smart App Control or antivirus &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#smart-app-control-blocks-the-installer-windows">Fix &rarr;</a></li>
-          <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch">Fix &rarr;</a></li>
+          <li>Installer blocked by Smart App Control or antivirus &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#smart-app-control-blocks-the-installer-windows" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
+          <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
         </ul>
       </div>
 
@@ -305,8 +305,8 @@
           Common issues
         </div>
         <ul>
-          <li>&ldquo;Cannot verify the developer&rdquo; when opening the file &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#macos-security-warning-when-opening-command-file">Fix &rarr;</a></li>
-          <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch">Fix &rarr;</a></li>
+          <li>&ldquo;Cannot verify the developer&rdquo; when opening the file &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#macos-security-warning-when-opening-command-file" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
+          <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
         </ul>
       </div>
 
@@ -332,7 +332,7 @@
         <strong>System Settings &gt; Privacy &amp; Security</strong>, scroll down to
         <strong>Security</strong>, click <strong>Open Anyway</strong> next to the blocked file,
         then confirm with your password or Touch ID. This is a one-time step per file.
-        <br><a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/GATEKEEPER.md"
+        <br><a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/GATEKEEPER.md" target="_blank" rel="noopener noreferrer"
            style="color:#38bdf8; text-decoration:underline">See the detailed guide &rarr;</a>
       </div>
 
@@ -393,8 +393,8 @@
           Common issues
         </div>
         <ul>
-          <li>Double-click opens the file in a text editor &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear">Fix &rarr;</a></li>
-          <li>Langflow Web missing from your app menu or desktop &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear">Fix &rarr;</a></li>
+          <li>Double-click opens the file in a text editor &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
+          <li>Langflow Web missing from your app menu or desktop &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
         </ul>
       </div>
 
@@ -466,7 +466,7 @@
 
     <!-- Help -->
     <div class="help">
-      <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md">
+      <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md" target="_blank" rel="noopener noreferrer">
         Having trouble? See the troubleshooting guide &rarr;
       </a>
     </div>
@@ -490,7 +490,7 @@
   </div>
 
   <!-- Floating help button -->
-  <a class="help-fab" href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md">
+  <a class="help-fab" href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md" target="_blank" rel="noopener noreferrer">
     <span class="help-fab-icon">?</span>
     Need help?
   </a>


### PR DESCRIPTION
This PR adds `target="_blank" rel="noopener noreferrer"` to all doc links on the landing page so the common-issues fix links, floating Need-help button, bottom guide link, and macOS Gatekeeper guide link keep the installer page open.

No other changes; `scripts/verify.sh` passes 12/12.