### PR TITLE
docs: update changelog for v1.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.9.7 (2026-08-22)
+
+- feat: upgrade Langflow to 1.11.4 (MCP SDK backport pin, FastAPI range restore, dependency security floors)
+- fix: friendlier first-launch wait messages in server launchers (varied progress updates every minute with elapsed time instead of identical lines every 5 seconds)
+- fix: realistic wait expectations for slow machines (intro box states up to 10-15 minutes; manual-URL hint removed from mid-wait messages, one-time log pointer after 15 minutes)
+- docs: friendlier landing page copy (hero star ask, first-start expectations in run steps, timing tips per OS tab)
+- docs: surface the troubleshooting guide prominently (always-visible Need-help button plus common-issues cards deep-linking each symptom)
+- docs: open troubleshooting links in a new tab
+
 ## v1.9.6 (2026-08-13)
 
 - feat: upgrade Langflow to 1.11.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - docs: friendlier landing page copy (hero star ask, first-start expectations in run steps, timing tips per OS tab)
 - docs: surface the troubleshooting guide prominently (always-visible Need-help button plus common-issues cards deep-linking each symptom)
 - docs: open troubleshooting links in a new tab
+- chore: bump uv to 0.12.5
 
 ## v1.9.6 (2026-08-13)
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 powershell = "7.6.3"
 shellcheck = "0.11.0"
 shfmt = "3.13.1"
-uv = "0.12.3"
+uv = "0.12.5"
 
 [env]
 BASH_FILES = "src/install-langflow.sh src/stop-langflow.sh scripts/verify.sh scripts/verify-install.sh scripts/package.sh 'Install Langflow.sh' 'Stop Langflow.sh'"


### PR DESCRIPTION
This PR prepares the v1.9.7 release by adding the changelog entry covering the Langflow 1.11.4 upgrade, the launcher wait-message fixes, and the landing-page improvements.

Script versions are already at 1.9.7 and all version references were updated in #50, so this is the only remaining step before tagging.

After squash merge: `git checkout main && git pull && git tag v1.9.7 && git push origin v1.9.7` — CI then runs verify + OS-matrix install test and publishes the release with notes generated from CHANGELOG.md.