### PR TITLE
chore: bump script version to 1.9.8

### DIFF
--- a/src/install-langflow-script.ps1
+++ b/src/install-langflow-script.ps1
@@ -17,7 +17,7 @@
     Justification = 'Kept as a single source of truth for the script version, mirrored in the bash installer.')]
 param()
 
-$ScriptVersion   = "1.9.7"
+$ScriptVersion   = "1.9.8"
 $LangflowVersion = "1.11.5"
 $PythonVersion   = "3.12"
 $LangflowDir     = "$env:USERPROFILE\langflow"

--- a/src/install-langflow.sh
+++ b/src/install-langflow.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 OS="$(uname -s)"
 # shellcheck disable=SC2034  # kept as the single source of truth for the script version
-SCRIPT_VERSION="1.9.7"
+SCRIPT_VERSION="1.9.8"
 LANGFLOW_VERSION="1.11.5"
 PYTHON_VERSION="3.12"
 LANGFLOW_DIR="$HOME/langflow"


### PR DESCRIPTION
This PR fixes the script version mismatch left on main after the Langflow 1.11.5 upgrade.

The changelog was bumped to v1.9.8 but the `$ScriptVersion` (PowerShell) and `SCRIPT_VERSION` (bash) installer versions stayed at 1.9.7. This aligns both to 1.9.8 so every file reports the same version.