### PR TITLE
fix: keep OS caveats visible via collapsible warnings on landing page

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,58 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Non-technical users who want to try Langflow but aren't comfortable with Python, pip, or command line tools. These users need a simple, one-click solution that handles all technical setup automatically.
+
+## Product Purpose
+
+Provide single-click installers for Langflow on Windows, macOS, and Linux that require no administrative privileges. Success means users can install and run Langflow without understanding Python environments, package managers, or terminal commands.
+
+## Positioning
+
+The installer eliminates the technical barriers that prevent non-technical users from trying Langflow. Unlike manual installation guides, this requires zero command-line knowledge and works without admin rights, making Langflow accessible to anyone with a computer.
+
+## Operating Context
+
+- Users download a zip file from GitHub Releases
+- Double-click a launcher file (`.bat`, `.command`, or `.sh`)
+- Follow a simple menu prompt to install
+- Desktop shortcuts are created for easy access
+- The installer handles Python, uv, and Langflow setup automatically
+
+## Capabilities and Constraints
+
+- **Cross-platform**: Windows 10/11, macOS 12+, and Linux
+- **No admin rights**: All installations occur under user profile directories
+- **Idempotent**: Safe to re-run; checks dependencies before acting
+- **Version pinned**: Langflow 1.11.5 with Python 3.12
+- **uv package manager**: Self-bootstrapping, no pre-installed Python required
+- **Desktop shortcuts**: Created for starting and stopping Langflow
+- **Browser auto-launch**: Opens `http://127.0.0.1:7860` when ready
+
+## Brand Commitments
+
+- Author attribution displayed on every script run (GitHub + LinkedIn)
+- MIT licensed
+- GitHub stars encouraged as primary feedback mechanism
+
+## Evidence on Hand
+
+- Landing page: `docs/index.html` (GitHub Pages)
+- Installation scripts: `src/install-langflow-script.ps1` (Windows), `src/install-langflow.sh` (macOS/Linux)
+- Troubleshooting documentation: `docs/TROUBLESHOOTING.md`, `docs/GATEKEEPER.md`
+- CI/CD: Automated verification and release workflows
+
+## Product Principles
+
+1. **Simplicity over flexibility**: One-click install with sensible defaults, no configuration options
+2. **No admin rights**: Everything installs under user profile directories
+3. **Idempotent operations**: Safe to re-run without side effects
+4. **Clear error messages**: Users understand what went wrong and how to fix it
+5. **Platform-native behavior**: Each platform uses appropriate tools and conventions

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,6 +117,41 @@
     }
     .issues a:hover { text-decoration: underline; }
 
+    /* Collapsible warnings */
+    details.warnings {
+      background: #1e293b; border: 1px solid #334155; border-radius: 12px;
+      margin: 0 0 2rem; overflow: hidden;
+    }
+    details.warnings summary {
+      display: flex; align-items: center; gap: 0.5rem;
+      padding: 1rem 1.25rem; cursor: pointer;
+      font-size: 0.95rem; font-weight: 600; color: #f8fafc;
+      list-style: none; user-select: none;
+    }
+    details.warnings summary::-webkit-details-marker { display: none; }
+    details.warnings summary:hover { background: #334155; }
+    details.warnings summary svg { width: 16px; height: 16px; fill: #fbbf24; flex-shrink: 0; }
+    details.warnings summary .chevron {
+      margin-left: auto; width: 14px; height: 14px; fill: #94a3b8;
+      transition: transform 0.2s ease;
+    }
+    details.warnings[open] summary .chevron { transform: rotate(90deg); }
+    details.warnings .warnings-body {
+      border-top: 1px solid #334155; padding: 1rem 1.25rem;
+    }
+    details.warnings .warnings-body ul { list-style: none; padding: 0; margin: 0; }
+    details.warnings .warnings-body ul li {
+      padding: 0.35rem 0 0.35rem 1.5rem; position: relative; color: #cbd5e1; font-size: 0.9rem;
+    }
+    details.warnings .warnings-body ul li::before { content: "\26A0"; position: absolute; left: 0; color: #fbbf24; }
+    details.warnings .warnings-body a {
+      color: #38bdf8; text-decoration: none;
+      white-space: nowrap; font-weight: 600;
+    }
+    details.warnings .warnings-body a:hover { text-decoration: underline; }
+    details.warnings .warnings-body p { font-size: 0.9rem; color: #cbd5e1; margin: 0 0 0.5rem; }
+    details.warnings .warnings-body p:last-child { margin-bottom: 0; }
+
     /* Floating help button */
     .help-fab {
       position: fixed; bottom: 1.25rem; right: 1.25rem; z-index: 100;
@@ -214,16 +249,19 @@
         <div class="download-sub">~56 KB &middot; Windows 10 / 11</div>
       </div>
 
-      <div class="issues">
-        <div class="issues-header">
+      <details class="warnings">
+        <summary>
           <svg viewBox="0 0 24 24"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"/></svg>
           Common issues
+          <svg class="chevron" viewBox="0 0 24 24"><path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+        </summary>
+        <div class="warnings-body">
+          <ul>
+            <li>Installer blocked by Smart App Control or antivirus &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#smart-app-control-blocks-the-installer-windows" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
+            <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
+          </ul>
         </div>
-        <ul>
-          <li>Installer blocked by Smart App Control or antivirus &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#smart-app-control-blocks-the-installer-windows" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
-          <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
-        </ul>
-      </div>
+      </details>
 
       <h2>How to install</h2>
       <div class="steps">
@@ -299,16 +337,19 @@
         <div class="download-sub">~32 KB &middot; macOS 12+ (Intel &amp; Apple Silicon)</div>
       </div>
 
-      <div class="issues">
-        <div class="issues-header">
+      <details class="warnings">
+        <summary>
           <svg viewBox="0 0 24 24"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"/></svg>
           Common issues
+          <svg class="chevron" viewBox="0 0 24 24"><path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+        </summary>
+        <div class="warnings-body">
+          <ul>
+            <li>&ldquo;Cannot verify the developer&rdquo; when opening the file &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#macos-security-warning-when-opening-command-file" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
+            <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
+          </ul>
         </div>
-        <ul>
-          <li>&ldquo;Cannot verify the developer&rdquo; when opening the file &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#macos-security-warning-when-opening-command-file" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
-          <li>Browser says the site can&rsquo;t be reached on first launch &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#browser-says-the-site-cant-be-reached-on-first-launch" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
-        </ul>
-      </div>
+      </details>
 
       <h2>How to install</h2>
       <div class="steps">
@@ -326,15 +367,20 @@
         </div>
       </div>
 
-      <div class="tip">
-        <strong>&#9888;&#65039; First time opening a .command file?</strong> &mdash;
-        Double-clicking will show &ldquo;macOS cannot verify the developer.&rdquo; Go to
-        <strong>System Settings &gt; Privacy &amp; Security</strong>, scroll down to
-        <strong>Security</strong>, click <strong>Open Anyway</strong> next to the blocked file,
-        then confirm with your password or Touch ID. This is a one-time step per file.
-        <br><a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/GATEKEEPER.md" target="_blank" rel="noopener noreferrer"
-           style="color:#38bdf8; text-decoration:underline">See the detailed guide &rarr;</a>
-      </div>
+      <details class="warnings" open>
+        <summary>
+          <svg viewBox="0 0 24 24"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"/></svg>
+          First time opening a .command file? (Gatekeeper)
+          <svg class="chevron" viewBox="0 0 24 24"><path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+        </summary>
+        <div class="warnings-body">
+          <p>Double-clicking will show &ldquo;macOS cannot verify the developer.&rdquo; Go to
+          <strong>System Settings &gt; Privacy &amp; Security</strong>, scroll down to
+          <strong>Security</strong>, click <strong>Open Anyway</strong> next to the blocked file,
+          then confirm with your password or Touch ID. This is a one-time step per file.
+          <br><a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/GATEKEEPER.md" target="_blank" rel="noopener noreferrer">See the detailed guide &rarr;</a></p>
+        </div>
+      </details>
 
       <h2>What the script does</h2>
       <ul>
@@ -387,16 +433,19 @@
         <div class="download-sub">~32 KB &middot; Any modern Linux distribution</div>
       </div>
 
-      <div class="issues">
-        <div class="issues-header">
+      <details class="warnings">
+        <summary>
           <svg viewBox="0 0 24 24"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"/></svg>
           Common issues
+          <svg class="chevron" viewBox="0 0 24 24"><path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+        </summary>
+        <div class="warnings-body">
+          <ul>
+            <li>Double-click opens the file in a text editor &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
+            <li>Langflow Web missing from your app menu or desktop &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
+          </ul>
         </div>
-        <ul>
-          <li>Double-click opens the file in a text editor &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
-          <li>Langflow Web missing from your app menu or desktop &mdash; <a href="https://github.com/NikkiSatmaka/langflow-installer-wrapper/blob/main/docs/TROUBLESHOOTING.md#linux-desktop-shortcut-doesnt-appear" target="_blank" rel="noopener noreferrer">Fix &rarr;</a></li>
-        </ul>
-      </div>
+      </details>
 
       <h2>How to install</h2>
       <div class="steps">
@@ -458,10 +507,16 @@
         </div>
       </div>
 
-      <div class="tip">
-        <strong>&#9888;&#65039; If double-click opens the file in a text editor</strong> &mdash;
-        Right-click the file, go to <em>Properties</em> &gt; <em>Permissions</em>, and check <em>Allow executing as program</em>. Then double-click again and choose <em>Run in Terminal</em>.
-      </div>
+      <details class="warnings">
+        <summary>
+          <svg viewBox="0 0 24 24"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"/></svg>
+          If double-click opens the file in a text editor
+          <svg class="chevron" viewBox="0 0 24 24"><path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+        </summary>
+        <div class="warnings-body">
+          <p>Right-click the file, go to <em>Properties</em> &gt; <em>Permissions</em>, and check <em>Allow executing as program</em>. Then double-click again and choose <em>Run in Terminal</em>.</p>
+        </div>
+      </details>
     </div>
 
     <!-- Help -->


### PR DESCRIPTION
This PR restores the original landing page and keeps its important OS-specific caveats (Smart App Control, Gatekeeper, Linux trust/executable steps) visible by folding them into collapsible warnings instead of hiding them in the minimal redesign. It also adds PRODUCT.md as durable product context captured during the design session.